### PR TITLE
chore: build PRs only if the event comes from Dependabot

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   multiplatform_build:
+    # Build PRs only if the event comes from Dependabot. Skip branch pushes
+    if: github.event.pull_request.user.login != 'dependabot[bot]' || github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Dependabot creates a branch within the repository and it creates a PR as well.
We should skip "branch-related CI" as Dependabot-created branches miss secrets anyway, so building PRs is just enough.