### PR TITLE
Fix the logic to generate timestamps in tests

### DIFF
--- a/integration-tests/robot/tests/libs/JaegerLibrary.py
+++ b/integration-tests/robot/tests/libs/JaegerLibrary.py
@@ -13,7 +13,6 @@ def generate_trace():
     utc_time = dt.replace(tzinfo=timezone.utc)
     timestamp = utc_time.timestamp()
     parent_id = _generate_id(16)
-    # child_id = _generate_id(16)
 
     fs = data[0]
     fs['traceId'] = parent_id
@@ -21,19 +20,11 @@ def generate_trace():
     fs['timestamp'] = _format_tmstmp(timestamp)
     fs['annotations'][0]['timestamp'] = _format_tmstmp(timestamp)
     fs['annotations'][1]['timestamp'] = _format_tmstmp(timestamp + 0.014861)
-    # ss = data[1]
-    # ss['traceId'] = parent_id
-    # ss['parentId'] = parent_id
-    # ss['id'] = child_id
-    # ss['timestamp'] = _format_tmstmp(timestamp + 0.000895)
-    # ss['annotations'][0]['timestamp'] = _format_tmstmp(timestamp + 0.000895)
-    # ss['annotations'][1]['timestamp'] = _format_tmstmp(timestamp + 0.002993)
-    # ss['annotations'][2]['timestamp'] = _format_tmstmp(timestamp + 0.004255)
-    # ss['annotations'][3]['timestamp'] = _format_tmstmp(timestamp + 0.004289)
+
     return data
 
 
-def _format_tmstmp(timestamp, ch_count=16):
+def _format_tmstmp(timestamp, ch_count=17):
     return int(''.join(str(timestamp).split('.'))[:ch_count])
 
 

--- a/integration-tests/robot/tests/libs/JaegerLibrary.py
+++ b/integration-tests/robot/tests/libs/JaegerLibrary.py
@@ -1,7 +1,7 @@
+import datetime
 import json
 import random
 from datetime import timezone
-import datetime
 
 
 def generate_trace():


### PR DESCRIPTION
# What does this PR do?

Integration tests have logic to generate test traces (and select these traces using the API) to verify how Jaeger receives traces.

Generated traces successfully stored but could not be selected using API.

## Root cause

Generated traces contain a timestamp with 16 digits instead of 17. As a result, timestamps converted to incorrect data (to 1975 year).

Example:

* timestamp - 173876535779301
* human date - Sunday, July 6, 1975 11:02:15.779 AM

## Solution

Fix the function to generate/convert timestamp.