### PR TITLE
Tests refactor timestamp handling to ensure 16-character format

### DIFF
--- a/integration-tests/robot/tests/libs/JaegerLibrary.py
+++ b/integration-tests/robot/tests/libs/JaegerLibrary.py
@@ -1,31 +1,28 @@
-import datetime
 import json
 import random
-from datetime import timezone
+from datetime import datetime, timezone
 
 
 def generate_trace():
     with open('./tests/libs/resources/spans.json') as f:
         data = json.load(f)
 
-    dt = datetime.datetime.now(timezone.utc)
+    timestamp = _generate_timestamp()
 
-    utc_time = dt.replace(tzinfo=timezone.utc)
-    timestamp = utc_time.timestamp()
     parent_id = _generate_id(16)
 
     fs = data[0]
     fs['traceId'] = parent_id
     fs['id'] = parent_id
-    fs['timestamp'] = _format_tmstmp(timestamp)
-    fs['annotations'][0]['timestamp'] = _format_tmstmp(timestamp)
-    fs['annotations'][1]['timestamp'] = _format_tmstmp(timestamp + 0.014861)
-
+    fs['timestamp'] = timestamp
+    fs['annotations'][0]['timestamp'] = timestamp
+    fs['annotations'][1]['timestamp'] = timestamp + 14861
     return data
 
 
-def _format_tmstmp(timestamp, ch_count=17):
-    return int(''.join(str(timestamp).split('.'))[:ch_count])
+def _generate_timestamp():
+    timestamp = int(datetime.now(timezone.utc).timestamp() * 1_000_000)
+    return timestamp if timestamp % 10 != 0 else timestamp - 1
 
 
 def _generate_id(n):

--- a/integration-tests/robot/tests/libs/JaegerLibrary.py
+++ b/integration-tests/robot/tests/libs/JaegerLibrary.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 
 def generate_trace():
-    with open('./tests/libs/resources/spans.json') as f:
+    with open("./tests/libs/resources/spans.json") as f:
         data = json.load(f)
 
     timestamp = _generate_timestamp()
@@ -12,11 +12,11 @@ def generate_trace():
     parent_id = _generate_id(16)
 
     fs = data[0]
-    fs['traceId'] = parent_id
-    fs['id'] = parent_id
-    fs['timestamp'] = timestamp
-    fs['annotations'][0]['timestamp'] = timestamp
-    fs['annotations'][1]['timestamp'] = timestamp + 14861
+    fs["traceId"] = parent_id
+    fs["id"] = parent_id
+    fs["timestamp"] = timestamp
+    fs["annotations"][0]["timestamp"] = timestamp
+    fs["annotations"][1]["timestamp"] = timestamp + 14861
     return data
 
 
@@ -26,4 +26,4 @@ def _generate_timestamp():
 
 
 def _generate_id(n):
-    return ''.join(random.choices('0123456789abcdef', k=n))
+    return "".join(random.choices("0123456789abcdef", k=n))


### PR DESCRIPTION
Refactors the timestamp generation logic to ensure it consistently has 16 characters and does not end in 0.

* Removed `_format_tmstmp()`, replaced with direct `timestamp * 1_000_000`.
* Ensured the last digit is not 0 to match the expected format.
* All other logic remains unchanged.