### PR TITLE
feat: Add asset upload job for Helm charts and documentation

### DIFF
--- a/.github/assets-config.yml
+++ b/.github/assets-config.yml
@@ -3,5 +3,5 @@ archives:
     outputName: helm-charts
     archiveType: tar.gz
   - source: docs
-    outputName: docks
+    outputName: docs
     archiveType: tar

--- a/.github/assets-config.yml
+++ b/.github/assets-config.yml
@@ -1,0 +1,7 @@
+archives:
+  - source: charts
+    outputName: helm-charts
+    archiveType: tar.gz
+  - source: docs
+    outputName: docks
+    archiveType: tar

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -125,12 +125,3 @@ jobs:
     with:
       version: ${{ github.event.inputs.version }}
       publish: false
-
-  upload-assets:
-    needs: [tag, docker-build]
-    uses: netcracker/qubership-workflow-hub/actions/archive-and-upload-assets@main
-    with:
-      config-path: './.github/assets-config.yml'
-      dist-path: './dist'
-      upload: true
-      ref: v${{ github.event.inputs.version }}

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -100,7 +100,7 @@ jobs:
           chart-yaml-path: ${{ github.event.inputs.path-to-chart }}
 
       - name: Run Commit and Push Action
-        uses: Netcracker/qubership-workflow-hub/actions/commit-and-push@main
+        uses: netcracker/qubership-workflow-hub/actions/commit-and-push@main
         with:
           commit_message: "Update chart version to v${{ github.event.inputs.version }}"
   tag:
@@ -125,3 +125,13 @@ jobs:
     with:
       version: ${{ github.event.inputs.version }}
       publish: false
+
+  
+  upload-assets:
+    needs: [tag, docker-build]
+    uses: netcracker/qubership-workflow-hub/actions/archive-and-upload-assets@main
+    with:
+      config-path: './.github/assets-config.yaml'
+      dist-path: './dist'
+      upload: true
+      ref: v${{ github.event.inputs.version }}

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -140,3 +140,5 @@ jobs:
           dist-path: './dist'
           upload: true
           ref: v${{ github.event.inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: Archive and Upload Assets
         uses: netcracker/qubership-workflow-hub/actions/archive-and-upload-assets@main
         with:
-          config-path: './.github/assets-config.yaml'
+          config-path: './.github/assets-config.yml'
           dist-path: './dist'
           upload: true
           ref: v${{ github.event.inputs.version }}

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -100,7 +100,7 @@ jobs:
           chart-yaml-path: ${{ github.event.inputs.path-to-chart }}
 
       - name: Run Commit and Push Action
-        uses: netcracker/qubership-workflow-hub/actions/commit-and-push@main
+        uses: Netcracker/qubership-workflow-hub/actions/commit-and-push@main
         with:
           commit_message: "Update chart version to v${{ github.event.inputs.version }}"
   tag:
@@ -120,7 +120,7 @@ jobs:
       platforms: ${{ needs.load-docker-build-components.outputs.platforms }}
 
   github-release:
-    needs: [tag]
+    needs: [tag, docker-build]
     uses: netcracker/qubership-workflow-hub/.github/workflows/release-drafter.yml@main
     with:
       version: ${{ github.event.inputs.version }}
@@ -142,3 +142,4 @@ jobs:
           ref: v${{ github.event.inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -126,12 +126,17 @@ jobs:
       version: ${{ github.event.inputs.version }}
       publish: false
 
-  
   upload-assets:
     needs: [tag, docker-build]
-    uses: netcracker/qubership-workflow-hub/actions/archive-and-upload-assets@main
-    with:
-      config-path: './.github/assets-config.yaml'
-      dist-path: './dist'
-      upload: true
-      ref: v${{ github.event.inputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Archive and Upload Assets
+        uses: netcracker/qubership-workflow-hub/actions/archive-and-upload-assets@main
+        with:
+          config-path: './.github/assets-config.yaml'
+          dist-path: './dist'
+          upload: true
+          ref: v${{ github.event.inputs.version }}

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -127,7 +127,7 @@ jobs:
       publish: false
 
   upload-assets:
-    needs: [tag]
+    needs: [github-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -125,3 +125,12 @@ jobs:
     with:
       version: ${{ github.event.inputs.version }}
       publish: false
+
+  upload-assets:
+    needs: [tag, docker-build]
+    uses: netcracker/qubership-workflow-hub/actions/archive-and-upload-assets@main
+    with:
+      config-path: './.github/assets-config.yml'
+      dist-path: './dist'
+      upload: true
+      ref: v${{ github.event.inputs.version }}

--- a/.github/workflows/jaeger-release.yaml
+++ b/.github/workflows/jaeger-release.yaml
@@ -120,14 +120,14 @@ jobs:
       platforms: ${{ needs.load-docker-build-components.outputs.platforms }}
 
   github-release:
-    needs: [tag, docker-build]
+    needs: [tag]
     uses: netcracker/qubership-workflow-hub/.github/workflows/release-drafter.yml@main
     with:
       version: ${{ github.event.inputs.version }}
       publish: false
 
   upload-assets:
-    needs: [tag, docker-build]
+    needs: [tag]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/charts/qubership-jaeger/Chart.yaml
+++ b/charts/qubership-jaeger/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 
 # to the chart and its templates, including the app version.
-version: 1.0.1
+version: 0.21.1
 # This is the version number of the application being deployed. This version number should be
 
 # incremented each time you make changes to the application.


### PR DESCRIPTION
Introduce a new asset upload job to the jaeger-release workflow, enabling the archiving of Helm charts and documentation. Update configuration files and dependencies to streamline the process.