### PR TITLE
fix: change the logic of readiness-probe to decrease the probe interval

### DIFF
--- a/.github/dev-metadata-config.yml
+++ b/.github/dev-metadata-config.yml
@@ -3,6 +3,7 @@ branches-template:
 - feature/*: "{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{short-sha}}"
 - hotfix/*: "{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{short-sha}}"
 - bugfix/*: "{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{short-sha}}"
+- fix/*: "{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{short-sha}}"
 - chore/*: "{{ref-name}}-{{timestamp}}, {{ref-name}}-{{short-sha}}, {{short-sha}}"
 distribution-tags:
 - main: "main"

--- a/charts/qubership-jaeger/templates/collector/deployment.yaml
+++ b/charts/qubership-jaeger/templates/collector/deployment.yaml
@@ -133,7 +133,7 @@ spec:
           args:
             {{- template "collector.args" . }}
           env:
-            {{- /* Section with Cassandra enviroment variables */}}
+            {{- /* Section with Cassandra environment variables */}}
             {{- if eq .Values.jaeger.storage.type "cassandra" }}
             - name: CASSANDRA_USERNAME
               valueFrom:
@@ -145,7 +145,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "cassandraSchemaJob.secretName" . }}
                   key: password
-            {{- /* Section with ElasticSearch/OpenSearch enviroment variables */}}
+            {{- /* Section with ElasticSearch/OpenSearch environment variables */}}
             {{- else if eq .Values.jaeger.storage.type "elasticsearch" }}
             - name: ES_USERNAME
               valueFrom:
@@ -158,6 +158,16 @@ spec:
                   name: {{ if .Values.elasticsearch.existingSecret }}{{ .Values.elasticsearch.existingSecret }}{{- else }}jaeger-elasticsearch{{- end }}
                   key: password
             {{- end }}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: admin-http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 1
           {{- if .Values.readinessProbe.install }}
           readinessProbe:
             failureThreshold: 1
@@ -166,31 +176,21 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 1
-            periodSeconds: 300
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 10 }}
             successThreshold: 1
-            timeoutSeconds: 600
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 5 }}
           {{- else }}
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /status
-              port: healtcheck
+              path: /
+              port: admin-http
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           {{- end }}
-          livenessProbe:
-            failureThreshold: 5
-            httpGet:
-              path: /status
-              port: healthcheck
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            successThreshold: 1
-            timeoutSeconds: 1
           ports:
             {{- if .Values.collector.zipkinPort }}
             - containerPort: {{ .Values.collector.zipkinPort }}

--- a/charts/qubership-jaeger/templates/query/deployment.yaml
+++ b/charts/qubership-jaeger/templates/query/deployment.yaml
@@ -181,7 +181,7 @@ spec:
               {{- toYaml .Values.query.cmdlineParams | nindent 12 }}
             {{- end }}
           env:
-          {{- /* Section with Cassandra enviroment variables */}}
+          {{- /* Section with Cassandra environment variables */}}
           {{- if eq .Values.jaeger.storage.type "cassandra" }}
             - name: CASSANDRA_USERNAME
               valueFrom:
@@ -193,7 +193,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "cassandraSchemaJob.secretName" . }}
                   key: password
-          {{- /* Section with ElasticSearch/OpenSearch enviroment variables */}}
+          {{- /* Section with ElasticSearch/OpenSearch environment variables */}}
           {{- else if eq .Values.jaeger.storage.type "elasticsearch" }}
             - name: ES_USERNAME
               valueFrom:
@@ -213,8 +213,8 @@ spec:
           livenessProbe:
             failureThreshold: 5
             httpGet:
-              path: /status
-              port: healthcheck
+              path: /
+              port: admin-http
               scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 15
@@ -228,17 +228,17 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 1
-            periodSeconds: 300
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 10}}
             successThreshold: 1
-            timeoutSeconds: 600
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 5 }}
           {{- else }}
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /status
-              port: healtcheck
+              path: /
+              port: admin-http
               scheme: HTTP
-            initialDelaySeconds: 15
+            initialDelaySeconds: 1
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -119,7 +119,7 @@ proxy:
     - dGVzdDp0ZXN0
 
   # The resources describe to compute resource requests and limits for single Pods.
-  # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # Type: object
   # Mandatory: no
   # Default:
@@ -435,7 +435,7 @@ elasticsearch:
     tolerations: {}
 
     # The resources describe to compute resource requests and limits for single Pods.
-    # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     # Type: object
     # Mandatory: no
     #
@@ -620,7 +620,7 @@ elasticsearch:
 
 
     # The resources describe to compute resource requests and limits for single Pods.
-    # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     # Type: object
     # Mandatory: no
     #
@@ -828,7 +828,7 @@ elasticsearch:
     extraSecretMounts: []
 
     # The resources describe to compute resource requests and limits for single Pods.
-    # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     # Type: object
     # Mandatory: no
     #
@@ -1027,7 +1027,7 @@ cassandraSchemaJob:
   password: ""
 
   # The resources describe to compute resource requests and limits for single Pods.
-  # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # Type: object
   # Mandatory: no
   #
@@ -1339,7 +1339,7 @@ agent:
   tolerations: {}
 
   # The resources describe to compute resource requests and limits for single Pods.
-  # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # Type: object
   # Mandatory: no
   #
@@ -1826,7 +1826,7 @@ collector:
         topologyKey: kubernetes.io/hostname
 
   # The resources describe to compute resource requests and limits for single Pods.
-  # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # Type: object
   # Mandatory: no
   #
@@ -2071,7 +2071,7 @@ hotrod:
     port: 6831
 
   # The resources describe to compute resource requests and limits for single Pods.
-  # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # Type: object
   # Mandatory: no
   #
@@ -2331,7 +2331,7 @@ query:
     #     - ALL
 
   # The resources describe to compute resource requests and limits for single Pods.
-  # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # Type: object
   # Mandatory: no
   #
@@ -2569,8 +2569,22 @@ readinessProbe:
   #   - "-retries=5"
   #   - "-timeout=5"
 
+  # How often (in seconds) to perform the readiness probe.
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  # Type: integer
+  # Mandatory: no
+  #
+  # periodSeconds: 10
+
+  # Number of seconds after which the readiness probe times out.
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  # Type: integer
+  # Mandatory: no
+  #
+  # periodSeconds: 5
+
   # The resources describe to compute resource requests and limits for single Pods.
-  # Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   # Type: object
   # Mandatory: no
   #

--- a/readiness-probe/main.go
+++ b/readiness-probe/main.go
@@ -25,6 +25,8 @@ import (
 
 var Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
+var isHealth = false
+
 type HttpClient struct {
 	client   http.Client
 	user     string
@@ -67,6 +69,15 @@ func main() {
 	}
 
 	go func() {
+		slog.Info("Readiness probe process is starting")
+		for {
+			isHealth = s.isHealth()
+			slog.Info("Sleep for 10 sec and try again")
+			time.Sleep(10 * time.Second)
+		}
+	}()
+
+	go func() {
 		slog.Info(fmt.Sprintf("The service is listening on 0.0.0.0:%d", s.servicePort))
 		if err := server.ListenAndServe(); err != nil {
 			if err != http.ErrServerClosed {
@@ -102,8 +113,8 @@ func initServer() *Server {
 	storage := flag.String("storage", "cassandra", "The type of storage for checking probe")
 	host := flag.String("host", "", "The host for probe")
 	port := flag.Int("port", 0, "The port for probe")
-	errors := flag.Int("errors", 5, "The number of retries for checking probe")
-	retries := flag.Int("retries", 5, "The number of allowed errors for checking probe")
+	errors := flag.Int("errors", 3, "The number of retries for checking probe")
+	retries := flag.Int("retries", 3, "The number of allowed errors for checking probe")
 	timeout := flag.Int("timeout", 5, "The number of seconds for failing probe by timeout")
 	tlsEnabled := flag.Bool("tlsEnabled", false, "Enabling TLS for connection to the storage")
 	insecureSkipVerify := flag.Bool("insecureSkipVerify", false, "Disabling host verification for TLS")
@@ -196,12 +207,10 @@ func createCassandraClient(host string, port int, user string, password string, 
 	cluster.NumConns = 1
 	if tlsEnabled {
 		if verification {
-			cluster.SslOpts.Config.InsecureSkipVerify = true
 			cluster.SslOpts = &gocql.SslOptions{
 				EnableHostVerification: !verification,
 			}
 		} else {
-			cluster.SslOpts.Config.InsecureSkipVerify = false
 			cluster.SslOpts = &gocql.SslOptions{
 				CertPath:               crt,
 				CaPath:                 ca,
@@ -275,7 +284,7 @@ func (s *Server) livenessProbe(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) readinessProbe(w http.ResponseWriter, _ *http.Request) {
-	if s.isHealth() {
+	if isHealth {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/text")
 		_, err := io.WriteString(w, http.StatusText(http.StatusOK))
@@ -314,8 +323,8 @@ func (s *Server) cassandraHealth() bool {
 		if errors >= s.errorsCount {
 			return false
 		}
-		slog.Info("Sleep for 10 sec and try again")
-		time.Sleep(10 * time.Second)
+		slog.Info("Sleep for 5 sec and try again")
+		time.Sleep(5 * time.Second)
 	}
 	return false
 }

--- a/readiness-probe/main.go
+++ b/readiness-probe/main.go
@@ -113,9 +113,11 @@ func initServer() *Server {
 	storage := flag.String("storage", "cassandra", "The type of storage for checking probe")
 	host := flag.String("host", "", "The host for probe")
 	port := flag.Int("port", 0, "The port for probe")
-	errors := flag.Int("errors", 3, "The number of retries for checking probe")
-	retries := flag.Int("retries", 3, "The number of allowed errors for checking probe")
+
+	errors := flag.Int("errors", 3, "The number of allowed errors for checking probe")
+	retries := flag.Int("retries", 3, "The number of retries for checking probe")
 	timeout := flag.Int("timeout", 5, "The number of seconds for failing probe by timeout")
+
 	tlsEnabled := flag.Bool("tlsEnabled", false, "Enabling TLS for connection to the storage")
 	insecureSkipVerify := flag.Bool("insecureSkipVerify", false, "Disabling host verification for TLS")
 


### PR DESCRIPTION
# What does this MR do?

There are two changes here:
* Started readiness probe in background and decreased errors, retries and sleep between errors
* Removed extra InsecureSkipVerify parameter due to TLSConfig is nil and there is `EnableHostVerification` parameter for `SslOpts` structure