### PR TITLE
feat: Add multi processor support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,5 +48,5 @@ jobs:
         no-cache: true
         context: ${{ matrix.component.context }}
         file: ${{ matrix.component.file }}
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: false


### PR DESCRIPTION
Added ARM64 as a processor under existing platform.

To validate from local to specific Kubernetes cluster :
$ kubectl exec -n <namespace> -it <podname> --kubeconfig <path of cert> -- uname -m

Expected output:

x86_64 → running on amd64

aarch64 → running on arm64
