### PR TITLE
fix: change the resource in which status check job save state

### DIFF
--- a/charts/qubership-jaeger/templates/status-provisioner/job.yaml
+++ b/charts/qubership-jaeger/templates/status-provisioner/job.yaml
@@ -58,7 +58,7 @@ spec:
           - name: TEMP
             value: /opt/robot/target
           - name: RESOURCE_TO_SET_STATUS
-            value: "batch v1 jobs integration-tests-status-provisioner"
+            value: "apps v1 deployments jaeger-collector"
           - name: CONDITION_REASON
             value: "IntegrationTestsExecutionStatus"
           - name: MONITORED_RESOURCES

--- a/charts/qubership-jaeger/templates/status-provisioner/role.yaml
+++ b/charts/qubership-jaeger/templates/status-provisioner/role.yaml
@@ -23,6 +23,7 @@ rules:
       - daemonsets/status
     verbs:
       - get
+      - patch
   - apiGroups:
       - batch
     resources:


### PR DESCRIPTION
# What does this PR do?

After converting the status provision Job from a regular Job to a post-deploy Helm hook, this job is still able to save the result state in the `.status`. But it continues to save it in the Job that should be removed after a successful run. It means that there is no way to check this state after installation or upgrade.

## Solution

Need to change the place where the status job will save the result:

* from the job itself
* to `jaeger-collector` deployment

The `jaeger-collector` deployment should always be installed, or the deployment will have no sense.

Also, need to add the `patch` permissions for the job role to allow patching the deployment in this namespace.