### PR TITLE
fix: change test expected status

### DIFF
--- a/integration-tests/robot/tests/shared/shared.robot
+++ b/integration-tests/robot/tests/shared/shared.robot
@@ -30,7 +30,7 @@ Preparation
 
 Convert Json ${json} To Type
     ${json_dictionary} =  Evaluate  json.loads('''${json}''')  json
-    [Return]  ${json_dictionary}
+    RETURN  ${json_dictionary}
 
 Check Inactive Deployments
     ${count_inactive_collectors} =  Get Inactive Deployment Entities Count For Service  ${JAEGER_NAMESPACE}  ${JAEGER_SERVICE_NAME}-collector
@@ -43,13 +43,13 @@ Check Deployment State
     ${deployments_in_namespace} =  Get Active Deployment Entities For Service  ${JAEGER_NAMESPACE}  ${name}  label=app.kubernetes.io/name
     ${list_len}=  Get Length  ${deployments_in_namespace}
     ${flag} =  Run Keyword And Return Status  Should Be True  ${list_len} != 0
-    [Return]  ${flag}
+    RETURN  ${flag}
 
 Check Jaeger Alive
     ${resp} =  GET On Session  healthcheck  /status  timeout=10
     Should Be Equal As Integers  ${resp.status_code}   200
     ${resp_json} =  Convert Json ${resp.content} To Type
-    Dictionary Should Contain Value  ${resp_json}  Server available
+    Dictionary Should Contain Value  ${resp_json}  StatusOK
 
 Post Random Spans
     [Arguments]  ${trace}


### PR DESCRIPTION
# What does this PR do?

The integration-tests failed with the error:

```bash
Jaeger can serve spans                                                | FAIL |
Dictionary does not contain value 'Server available'.
------------------------------------------------------------------------------
Tests.Smoke.Smoke                                                     | FAIL |
4 tests, 3 passed, 1 failed
==============================================================================
Tests.Smoke                                                           | FAIL |
4 tests, 3 passed, 1 failed
==============================================================================
Tests                                                                 | FAIL |
4 tests, 3 passed, 1 failed
==============================================================================
```

## Root cause

In version 1.x, Jaeger returns on the health endpoint the output:

```json
{'status': 'Server available', 'upSince': '2025-02-17T15:42:28.32801317Z', 'uptime': '27.977007058s'}
```

Since version 2.x it starts returning other fields:

```json
{'start_time': '2025-05-16T07:38:09.329829457Z', 'healthy': True, 'status': 'StatusOK', 'status_time': '2025-05-16T07:38:14.479770098Z'}
```

## Solution

Changes the expected value for the `status` field, from `Server available` to `StatusOK`.

Also, migrated to the new return keyword, about RobotFramework, wrote in the test output:

```bash
[ WARN ] Error in file '/opt/robot/tests/shared/shared.robot' on line 33: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/opt/robot/tests/shared/shared.robot' on line 46: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
```