### PR TITLE
fix: change the secret name in the helm pre-hook job

### DIFF
--- a/charts/qubership-jaeger/templates/_helpers.tpl
+++ b/charts/qubership-jaeger/templates/_helpers.tpl
@@ -1195,7 +1195,7 @@ Generate certificate volumes for TLS configuration
           path: client-key.pem
 {{- end }}
 {{- if and .Values.elasticsearch.client.tls.enabled (not .Values.elasticsearch.client.tls.insecureSkipVerify) }}
-- name: {{ .Values.jaeger.serviceName }}-elasticsearch-tls-assets
+- name: {{ template "elasticsearch.tls.secretName" . }}
   projected:
     sources:
     - secret:
@@ -1277,7 +1277,7 @@ Generate certificate volumes for OpenSearch jobs TLS configuration
 */}}
 {{- define "jaeger.opensearchCertificateVolumes" -}}
 {{- if and .Values.elasticsearch.client.tls.enabled (not .Values.elasticsearch.client.tls.insecureSkipVerify) }}
-- name: {{ .Values.jaeger.serviceName }}-elasticsearch-tls-assets
+- name: {{ template "elasticsearch.tls.secretName" . }}
   projected:
     sources:
     - secret:
@@ -1297,7 +1297,7 @@ Generate certificate volume mounts for OpenSearch jobs TLS configuration
 */}}
 {{- define "jaeger.opensearchCertificateVolumeMounts" -}}
 {{- if and .Values.elasticsearch.client.tls.enabled (not .Values.elasticsearch.client.tls.insecureSkipVerify) }}
-- name: {{ .Values.jaeger.serviceName }}-elasticsearch-tls-assets
+- name: {{ template "elasticsearch.tls.secretName" . }}
   mountPath: "/es-tls"
   readOnly: true
 {{- end }}

--- a/charts/qubership-jaeger/templates/opensearch/pre-hook/rollover-job.yaml
+++ b/charts/qubership-jaeger/templates/opensearch/pre-hook/rollover-job.yaml
@@ -101,7 +101,7 @@ spec:
           securityContext:
             {{- include "elasticsearch.rolloverjob.containerSecurityContext" . }}
           volumeMounts:
-          {{- include "jaeger.opensearchCertificateVolumeMounts" . | nindent 10 }}
+          {{- include "jaeger.opensearchCertificateVolumeMounts" (merge (dict "prehook" true) .) | nindent 10 }}
           {{- range .Values.elasticsearch.rollover.extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
@@ -115,7 +115,7 @@ spec:
               readOnly: {{ .readOnly }}
           {{- end }}
       volumes:
-      {{- include "jaeger.opensearchCertificateVolumes" . | nindent 6 }}
+      {{- include "jaeger.opensearchCertificateVolumes" (merge (dict "prehook" true) .) | nindent 6 }}
       {{- range .Values.elasticsearch.rollover.extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:


### PR DESCRIPTION
# What does this PR do?

The Jaeger deploy failed during the deploy with `rollover` and `lookback` jobs.

## Root cause

For the Helm pre-hook job and for the regular job are using secrets with different names:

* `%s-es-pre-hook-tls-assets` - for pre-hook jobs (`pre-install`, `pre-upgrade`)
* `%s-elasticsearch-tls-assets` - for regular jobs

And due to the mistake in one of the previous PRs for pre-hook job were used the name of the Secret was used for regular Jobs. But this Secret Helm should be created after a successful run of the pre-hook Job.

## Solution

Template `elasticsearch.tls.secretName` already supports two secret names for different cases. So changes:

* Added this template to calculate the Secret name in all necessary places
* Added to template call the construction `(merge (dict "prehook" true) .)` to tell Helm that we want to use the name for prehook