### PR TITLE
fix: Add an ability to set the common name for Cassandra's TLS settings

### DIFF
--- a/charts/qubership-jaeger/templates/collector/configmap-config.yaml
+++ b/charts/qubership-jaeger/templates/collector/configmap-config.yaml
@@ -83,6 +83,9 @@ data:
                 port: {{ if .Values.cassandraSchemaJob.port}}{{.Values.cassandraSchemaJob.port}}{{- else }}{{ if .Values.INFRA_CASSANDRA_PORT }}{{ .Values.INFRA_CASSANDRA_PORT }}{{ else}}9042{{- end }}{{- end }}
                 tls:
                   {{- if .Values.cassandraSchemaJob.tls.enabled }}
+                  {{- if .Values.cassandraSchemaJob.tls.commonName }}
+                  server_name_override: {{ .Values.cassandraSchemaJob.tls.commonName }}
+                  {{- end }}
                   {{- if .Values.cassandraSchemaJob.tls.insecureSkipVerify }}
                   insecure_skip_verify: true
                   {{- end }}

--- a/charts/qubership-jaeger/templates/query/configmap-config.yaml
+++ b/charts/qubership-jaeger/templates/query/configmap-config.yaml
@@ -99,6 +99,9 @@ data:
                 port: {{ if .Values.cassandraSchemaJob.port}}{{.Values.cassandraSchemaJob.port}}{{ else }}{{ if .Values.INFRA_CASSANDRA_PORT }}{{ .Values.INFRA_CASSANDRA_PORT }}{{ else}} 9042{{ end }}{{ end }}
                 tls:
                   {{- if .Values.cassandraSchemaJob.tls.enabled }}
+                  {{- if .Values.cassandraSchemaJob.tls.commonName }}
+                  server_name_override: {{ .Values.cassandraSchemaJob.tls.commonName }}
+                  {{- end }}
                   {{- if .Values.cassandraSchemaJob.tls.insecureSkipVerify }}
                   insecure_skip_verify: true
                   {{- end }}


### PR DESCRIPTION
# What does this PR do?

During the deploy of Jaeger with Cassandra storage and with TLS connection between Jaeger and Cassandra the Jaeger failed with the error in the logs:

```bahs
2025/05/26 15:01:36 error: failed to connect to "[HostInfo hostname="1.2.3.4" connectAddress="1.2.3.4" peer="1.2.3.4" rpc_address="1.2.3.4" broadcast_address="<nil>" preferred_ip="<nil>" connect_addr="1.2.3.4" connect_addr_source="connect_address" port=9042 data_centre="dc1" rack="rack1" host_id="d44264a0-27c2-4007-aa81-42b70f7537c7" version="v5.0.2" state=UP num_tokens=256]" due to error: tls: failed to verify certificate: x509: certificate is valid for 127.0.0.1, not 1.2.3.4
```

## Root cause

The `gocql` driver that Jaeger uses to all Cassandra connections always resolves the DNS names to IPs and uses these IPs to connect.

The cert-manager usually generates certificates without the actual IP, only for DNS and some local IPs like `127.0.0.1`.

## Solution

The Jaeger uses to set TLS parameters, the common structure for all OTEC settings:
https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md

It allows to set the

```yaml
tls:
  server_name_override: <name>
```

In the case of Kubernetes and Cassandra, it can be used to set the Cassandra Service name, like the following:

```yaml
tls:
  server_name_override: cassndra
```

So, need to add lost mapping from `commonName` (already existing parameter) to `server_name_override`.