### PR TITLE
fix: change-template formatting in release drafter config

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -22,8 +22,7 @@ categories:
     labels:
       - documentation
 
-change-template: |
-  - (#$NUMBER) $TITLE by @$AUTHOR
+change-template: "- (#$NUMBER) $TITLE by @$AUTHOR"
 
 no-changes-template: 'No significant changes'
 


### PR DESCRIPTION
fix: Correct the formatting of the change-template in the release drafter configuration for improved clarity.