### PR TITLE
fix: move to using the static mount name for Secret with TLS certs

### DIFF
--- a/charts/qubership-jaeger/templates/cassandra/pre-hook/schema-job.yaml
+++ b/charts/qubership-jaeger/templates/cassandra/pre-hook/schema-job.yaml
@@ -33,7 +33,6 @@ spec:
   {{- end }}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         job-name: {{ .Values.jaeger.serviceName }}-cassandra-schema
         name: {{ .Values.jaeger.serviceName }}-cassandra-schema

--- a/charts/qubership-jaeger/templates/collector/configmap-config.yaml
+++ b/charts/qubership-jaeger/templates/collector/configmap-config.yaml
@@ -24,7 +24,7 @@ metadata:
 data:
   config.yaml: |
     service:
-      extensions: {{ if .Values.collector.sampling.type }}[jaeger_storage, healthcheckv2, remote_sampling]{{ else }}[jaeger_storage ,healthcheckv2]{{- end }}
+      extensions: {{ if .Values.collector.sampling.type }}[jaeger_storage, healthcheckv2, remote_sampling]{{ else }}[jaeger_storage, healthcheckv2]{{- end }}
       pipelines:
         traces:
           receivers: [otlp, jaeger, zipkin]
@@ -147,7 +147,6 @@ data:
                 {{- end }}
               {{- end }}
           {{- end }}
-
     receivers:
       otlp:
         protocols:
@@ -155,9 +154,9 @@ data:
             endpoint: 0.0.0.0:4317
             {{- if $otelgrpcTlsConfigEnabled }}
             tls:
-              client_ca_file: /collector-tls/ca.crt
-              cert_file: /collector-tls/tls.crt
-              key_file: /collector-tls/tls.key
+              client_ca_file: /http-tls/ca.crt
+              cert_file: /http-tls/tls.crt
+              key_file: /http-tls/tls.key
               {{- if .Values.collector.tlsConfig.otelgRPC.cipherSuites }}
               cipher_suites:
               {{- range  .Values.collector.tlsConfig.otelgRPC.cipherSuites | split "," }}
@@ -188,9 +187,9 @@ data:
             endpoint: 0.0.0.0:4318
             {{- if $otelhttpTlsConfigEnabled }}
             tls:
-              client_ca_file: /collector-tls/ca.crt
-              cert_file: /collector-tls/tls.crt
-              key_file: /collector-tls/tls.key
+              client_ca_file: /http-tls/ca.crt
+              cert_file: /http-tls/tls.crt
+              key_file: /http-tls/tls.key
               {{- if .Values.collector.tlsConfig.otelHttp.cipherSuites }}
               cipher_suites:
               {{- range $suite := .Values.collector.tlsConfig.otelHttp.cipherSuites | split "," }}
@@ -233,9 +232,9 @@ data:
             endpoint: 0.0.0.0:14268
             {{- if $jaegerhttpTlsConfigEnabled }}
             tls:
-              cert_file: /collector-tls/tls.crt
-              client_ca_file: /collector-tls/ca.crt
-              key_file: /collector-tls/tls.key
+              cert_file: /http-tls/tls.crt
+              client_ca_file: /http-tls/ca.crt
+              key_file: /http-tls/tls.key
               {{- if .Values.collector.tlsConfig.jaegerHttp.maxVersion }}
               max_version: {{ .Values.collector.tlsConfig.jaegerHttp.maxVersion | quote }}
               {{- end }}
@@ -262,9 +261,9 @@ data:
             endpoint: 0.0.0.0:14250
             {{- if $jaegergrpcTlsConfigEnabled }}
             tls:
-              cert_file: /collector-tls/tls.crt
-              client_ca_file: /collector-tls/ca.crt
-              key_file: /collector-tls/tls.key
+              cert_file: /http-tls/tls.crt
+              client_ca_file: /http-tls/ca.crt
+              key_file: /http-tls/tls.key
               {{- if .Values.collector.tlsConfig.jaegergRPC.maxVersion }}
               max_version: {{ .Values.collector.tlsConfig.jaegergRPC.maxVersion | quote }}
               {{- end }}
@@ -303,9 +302,9 @@ data:
         {{- end }}
         {{- end }}
         tls:
-          cert_file: /collector-tls/tls.crt
-          client_ca_file: /collector-tls/ca.crt
-          key_file: /collector-tls/tls.key
+          cert_file: /http-tls/tls.crt
+          client_ca_file: /http-tls/ca.crt
+          key_file: /http-tls/tls.key
           {{- if .Values.collector.tlsConfig.zipkin.cipherSuites }}
           cipher_suites:
           {{- range $suite := .Values.collector.tlsConfig.zipkin.cipherSuites | split "," }}

--- a/charts/qubership-jaeger/templates/collector/deployment.yaml
+++ b/charts/qubership-jaeger/templates/collector/deployment.yaml
@@ -162,20 +162,20 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-            - mountPath: /etc/jaeger/sampling
-              name: {{ .Values.jaeger.serviceName }}-sampling-configuration-volume
+            - name: sampling-config
+              mountPath: /etc/jaeger/sampling
               readOnly: true
-            - mountPath: /conf
-              name: jaeger-collector-configuration-volume
+            - name: collector-config
+              mountPath: /conf
               readOnly: true
             {{- include "jaeger.certificateVolumeMounts" . | nindent 12 }}
         {{- if .Values.readinessProbe.install }}
-        - name: readiness-probe
+        - name: probe
           image: {{ template "readiness-probe.image" . }}
           imagePullPolicy: {{ .Values.readinessProbe.imagePullPolicy }}
           command: ["/app/probe"]
           args:
-            {{- template "readinessProbe.args" . }}
+            {{- include "readinessProbe.args" . }}
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -211,14 +211,14 @@ spec:
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30
       volumes:
-        - name: {{ .Values.jaeger.serviceName }}-sampling-configuration-volume
+        - name: sampling-config
           configMap:
             name: {{ .Values.jaeger.serviceName }}-sampling-configuration
             defaultMode: 420
             items:
               - key: sampling
                 path: sampling.json
-        - name: {{ .Values.jaeger.serviceName }}-collector-configuration-volume
+        - name: collector-config
           configMap:
             name: {{ .Values.jaeger.serviceName }}-collector-configuration
             items:

--- a/charts/qubership-jaeger/templates/collector/role.yaml
+++ b/charts/qubership-jaeger/templates/collector/role.yaml
@@ -3,7 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: jaeger-collector
   labels:
     name: jaeger-collector

--- a/charts/qubership-jaeger/templates/integration-tests/role.yaml
+++ b/charts/qubership-jaeger/templates/integration-tests/role.yaml
@@ -3,7 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: {{ .Values.integrationTests.serviceAccount.name }}-service-operator
   labels:
     name: {{ .Values.integrationTests.serviceAccount.name }}-service-operator

--- a/charts/qubership-jaeger/templates/query/deployment.yaml
+++ b/charts/qubership-jaeger/templates/query/deployment.yaml
@@ -147,11 +147,11 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-            - mountPath: /etc/config
-              name: {{ .Values.jaeger.serviceName }}-ui-configuration-volume
+            - name: ui-config
+              mountPath: /etc/config
               readOnly: true
-            - mountPath: /conf
-              name: {{ .Values.jaeger.serviceName }}-query-configuration-volume
+            - name: query-config
+              mountPath: /conf
               readOnly: true
             {{- include "jaeger.certificateVolumeMounts" . | nindent 12 }}
         {{- if .Values.proxy.install }}
@@ -197,9 +197,11 @@ spec:
           volumeMounts:
             - name: envoy-config
               mountPath: /envoy
+              readOnly: true
             {{- if eq .Values.proxy.type "oauth2" }}
             - name: oauth2-token
               mountPath: /envoy/oauth2
+              readOnly: true
             {{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -207,12 +209,12 @@ spec:
             {{- include "proxy.containerSecurityContext" . }}
         {{- end }}
         {{- if .Values.readinessProbe.install }}
-        - name: readiness-probe
+        - name: probe
           image: {{ template "readiness-probe.image" . }}
           imagePullPolicy: {{ .Values.readinessProbe.imagePullPolicy }}
           command: [ "/app/probe" ]
           args:
-            {{- template "readinessProbe.args" . }}
+            {{- include "readinessProbe.args" . }}
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -250,11 +252,11 @@ spec:
         {{- include "query.securityContext" . }}
       terminationGracePeriodSeconds: 30
       volumes:
-        - name: {{ .Values.jaeger.serviceName }}-ui-configuration-volume
+        - name: ui-config
           configMap:
             name: {{ .Values.jaeger.serviceName }}-ui-configuration
             defaultMode: 420
-        - name: {{ .Values.jaeger.serviceName }}-query-configuration-volume
+        - name: query-config
           configMap:
             name: {{ .Values.jaeger.serviceName }}-query-configuration
             items:

--- a/charts/qubership-jaeger/templates/query/role.yaml
+++ b/charts/qubership-jaeger/templates/query/role.yaml
@@ -3,7 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: jaeger-query
   labels:
     name: jaeger-query


### PR DESCRIPTION
# What does this PR do?
During the deployment of Jaeger with OpenSearch storage and with TLS connection and using the pre-created Secret, the deployment fails with the error:

```bash
Error: Deployment.apps "jaeger-query" is invalid: [spec.template.spec.containers[0].volumeMounts[2].name: Not found: "jaeger-elasticsearch-tls-assets", spec.template.spec.containers[1].volumeMounts[0].name: Not found: "jaeger-elasticsearch-tls-assets"] 
```

## Root cause

Not in all places of the template was the correct Secret name.

## Solution

Fix Secret names in all templates. To simplify templates, we can use the static names for Volume and VolumeMounts.