### PR TITLE
chore(deps): update default versions of Jaeger and it components

### DIFF
--- a/charts/qubership-jaeger/Chart.yaml
+++ b/charts/qubership-jaeger/Chart.yaml
@@ -7,8 +7,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.22.0
+version: 0.23.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.5.0
+appVersion: 2.7.0

--- a/charts/qubership-jaeger/templates/_helpers.tpl
+++ b/charts/qubership-jaeger/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Image can be found from:
   {{- if .Values.collector.image -}}
     {{- printf "%s" .Values.collector.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger:2.5.0" -}}
+    {{- print "jaegertracing/jaeger:2.7.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -156,7 +156,7 @@ Image can be found from:
   {{- if .Values.query.image -}}
     {{- printf "%s" .Values.query.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger:2.5.0" -}}
+    {{- print "jaegertracing/jaeger:2.7.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -169,7 +169,7 @@ Image can be found from:
   {{- if .Values.proxy.image -}}
     {{- printf "%s" .Values.proxy.image -}}
   {{- else -}}
-    {{- print "envoyproxy/envoy:v1.30.7" -}}
+    {{- print "envoyproxy/envoy:v1.32.6" -}}
   {{- end -}}
 {{- end -}}
 
@@ -182,7 +182,7 @@ Image can be found from:
   {{- if .Values.cassandraSchemaJob.image -}}
     {{- printf "%s" .Values.cassandraSchemaJob.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger-cassandra-schema:1.68.0" -}}
+    {{- print "jaegertracing/jaeger-cassandra-schema:1.70.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -195,7 +195,7 @@ Image can be found from:
   {{- if .Values.hotrod.image -}}
     {{- printf "%s" .Values.hotrod.image -}}
   {{- else -}}
-    {{- print "jaegertracing/example-hotrod:1.68.0" -}}
+    {{- print "jaegertracing/example-hotrod:1.70.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -208,7 +208,7 @@ Image can be found from:
   {{- if .Values.elasticsearch.indexCleaner.image -}}
     {{- printf "%s" .Values.elasticsearch.indexCleaner.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger-es-index-cleaner:1.68.0" -}}
+    {{- print "jaegertracing/jaeger-es-index-cleaner:1.70.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -221,7 +221,7 @@ Image can be found from:
   {{- if .Values.elasticsearch.rollover.image -}}
     {{- printf "%s" .Values.elasticsearch.rollover.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger-es-rollover:1.68.0" -}}
+    {{- print "jaegertracing/jaeger-es-rollover:1.70.0" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -39,9 +39,9 @@ proxy:
   # A docker image to use for envoy container.
   # Type: string
   # Mandatory: no
-  # Default: "envoyproxy/envoy:v1.20.0"
+  # Default: "envoyproxy/envoy:v1.32.6"
   #
-  # image: "envoyproxy/envoy:v1.20.0"
+  # image: "envoyproxy/envoy:v1.32.6"
 
   # Authentication type to be used
   # Available values - "basic" and "oauth2"
@@ -265,9 +265,9 @@ elasticsearch:
     # A docker image to use for index cleaner cronJob.
     # Type: string
     # Mandatory: no
-    # Default: "jaegertracing/jaeger-es-index-cleaner:1.33.0"
+    # Default: "jaegertracing/jaeger-es-index-cleaner:1.70.0"
     #
-    # image: "jaegertracing/jaeger-es-index-cleaner:1.33.0"
+    # image: "jaegertracing/jaeger-es-index-cleaner:1.70.0"
 
     # A name of a microservice to deploy with.
     # This name will be used as name of the microservice cronjob and in labels.
@@ -646,9 +646,9 @@ elasticsearch:
     # A docker image to use for rollover cronJob.
     # Type: string
     # Mandatory: no
-    # Default: "jaegertracing/jaeger-es-rollover:1.33.0"
+    # Default: "jaegertracing/jaeger-es-rollover:1.70.0"
     #
-    # image: "jaegertracing/jaeger-es-rollover:1.33.0"
+    # image: "jaegertracing/jaeger-es-rollover:1.70.0"
 
     # A name of a microservice to deploy with.
     # This name will be used as name of the microservice cronjob and in labels.
@@ -849,9 +849,9 @@ cassandraSchemaJob:
   # A docker image to use for cassandraSchemaJob job.
   # Type: string
   # Mandatory: no
-  # Default: "jaegertracing/jaeger-cassandra-schema:1.33.0"
+  # Default: "jaegertracing/jaeger-cassandra-schema:1.70.0"
   #
-  # image: "jaegertracing/jaeger-cassandra-schema:1.33.0"
+  # image: "jaegertracing/jaeger-cassandra-schema:1.70.0"
 
   # A name of a microservice to deploy with.
   # This name will be used as name of the microservice job and in labels.
@@ -1180,9 +1180,9 @@ collector:
   # A docker image to use for collector deployment.
   # Type: string
   # Mandatory: no
-  # Default: "jaegertracing/jaeger:2.2.0"
+  # Default: "jaegertracing/jaeger:2.7.0"
   #
-  # image: "jaegertracing/jaeger:2.2.0"
+  # image: "jaegertracing/jaeger:2.7.0"
 
   # A name of a microservice to deploy with.
   # This name will be used as name of the microservice deployment and in labels.
@@ -1736,9 +1736,9 @@ hotrod:
   # A docker image to use for hotrod deployment.
   # Type: string
   # Mandatory: no
-  # Default: "jaegertracing/example-hotrod:1.33.0"
+  # Default: "jaegertracing/example-hotrod:1.70.0"
   #
-  # image: "jaegertracing/example-hotrod:1.33.0"
+  # image: "jaegertracing/example-hotrod:1.70.0"
 
   # A name of a microservice to deploy with.
   # This name will be used as name of the microservice deployment and in labels.
@@ -1937,9 +1937,9 @@ query:
   # A docker image to use for query deployment.
   # Type: string
   # Mandatory: no
-  # Default: "jaegertracing/jaeger:2.2.0"
+  # Default: "jaegertracing/jaeger:2.7.0"
   #
-  # image: "jaegertracing/jaeger:2.2.0"
+  # image: "jaegertracing/jaeger:2.7.0"
 
   # The imagePullPolicy for a container and the tag of the image affect when the kubelet
   # attempts to pull (download) the specified image.


### PR DESCRIPTION
# What does this MR do?

Changes:
* Update the default versions of Jaeger and its components to `2.7.0`/`1.70.0`.
* Update envoy version to the latest `1.32.6`
* Bump chart version to current 0.23.0.


## How was it tested?

Deployed in Kubernetes and validated that the deployment is fine.

![image](https://github.com/user-attachments/assets/ecbb9cd1-6702-480c-bf42-b769773c39ee)