### PR TITLE
fix: Update container cleanup action to use main branch

### DIFF
--- a/.github/workflows/cleanup-old-containers-test.yaml
+++ b/.github/workflows/cleanup-old-containers-test.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "**Excluded tags**: ${{ github.event.inputs.excluded-tags || 'main,latest,release*,*.*' }}"
           echo "**Dry-run**: ${{ github.event.inputs.dry-run || 'false' }}"
       - name: Run Container Package Cleanup Action
-        uses: Netcracker/qubership-workflow-hub/actions/container-package-cleanup@feature/container-remove-ref
+        uses:  nookyo/qubership-workflow-hub/actions/container-package-cleanup@main
         with:
           threshold-days: ${{ github.event.inputs.threshold-days || 7 }}
           included-tags: ${{ github.event.inputs.included-tags || '*' }}


### PR DESCRIPTION
Change the container package cleanup action to reference the main branch instead of a feature branch.