### PR TITLE
fix: replace hardcoded path to write status to template that will calculate it

### DIFF
--- a/charts/qubership-jaeger/templates/_helpers.tpl
+++ b/charts/qubership-jaeger/templates/_helpers.tpl
@@ -1345,3 +1345,15 @@ Generate list of images for tests
       {{- printf "deployment %s %s %s, " .Values.integrationTests.service.name .Values.integrationTests.service.name "qubership/integration-tests" -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Generate custom resource path for integration tests
+This path built as "apps/v1/<namespace_name>/deployments/<deployment_name>"
+*/}}
+{{- define "integrationTests.customResourcePath" -}}
+  {{- if .Values.integrationTests.statusWriting.customResourcePath -}}
+    {{- .Values.integrationTests.statusWriting.customResourcePath -}}
+  {{- else -}}
+    {{- printf "apps/v1/%s/deployments/%s" .Release.Namespace .Values.integrationTests.service.name -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/qubership-jaeger/templates/integration-tests/deployment.yaml
+++ b/charts/qubership-jaeger/templates/integration-tests/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: IS_SHORT_STATUS_MESSAGE
               value: {{ .Values.integrationTests.statusWriting.isShortStatusMessage | quote }}
             - name: STATUS_CUSTOM_RESOURCE_PATH
-              value: {{ toYaml .Values.integrationTests.statusWriting.customResourcePath }}
+              value: {{ include "integrationTests.customResourcePath" . }}
           resources: {{ toYaml .Values.integrationTests.resources | nindent 12 }}
           securityContext:
             {{- include "integrationTests.containerSecurityContext" . }}

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -2176,13 +2176,13 @@ integrationTests:
     limits:
       memory: 256Mi
       cpu: 300m
+  service:
+    name: jaeger-integration-tests-runner
   statusWriting:
     enabled: true
     isShortStatusMessage: true
     onlyIntegrationTests: true
-    customResourcePath: "apps/v1/jaeger/deployments/jaeger-integration-tests-runner"
-  service:
-    name: jaeger-integration-tests-runner
+    # customResourcePath: "apps/v1/<namespace_name>/deployments/<deployment_name>"
   serviceAccount:
     create: true
     name: "jaeger-integration-tests"


### PR DESCRIPTION
# What does this MR do?

During deploy the Jaeger using this Helm chart with integration-tests, we received the error in the test container logs:

```bash
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"deployments.apps \"jaeger-integration-tests-runner\" is forbidden: User \"system:serviceaccount:tracing:jaeger-integration-tests\" cannot get resource \"deployments/status\" in API group \"apps\" in the namespace \"jaeger\"","reason":"Forbidden","details":{"name":"jaeger-integration-tests-runner","group":"apps","kind":"deployments"},"code":403} 
```

The root cause of this issue in fact that the integration-tests container is using special coordinates to understand where the status should be stored:

```yaml
integrationTests:
  statusWriting:
    customResourcePath: "apps/v1/<namespace_name>/deployments/<deployment_name>"
```

This path was built as:

```yaml
apps/v1/<namespace_name>/<deployment_type>/<deployment_name>
```

So now this path is hardcoded in the `main` branch and was hardcoded with the `namespace=jaeger`. Although the namespace name can be different.

## Solution

Need to build this path during deploy, using the coordinates and values that we have during deploy.
