### PR TITLE
chore(deps): update the default jaeger version to 2.11.0

### DIFF
--- a/charts/qubership-jaeger/Chart.yaml
+++ b/charts/qubership-jaeger/Chart.yaml
@@ -7,8 +7,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.25.3
+version: 0.25.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.10.0
+appVersion: 2.11.0

--- a/charts/qubership-jaeger/templates/_helpers.tpl
+++ b/charts/qubership-jaeger/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Image can be found from:
   {{- if .Values.collector.image -}}
     {{- printf "%s" .Values.collector.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger:2.10.0" -}}
+    {{- print "jaegertracing/jaeger:2.11.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -156,7 +156,7 @@ Image can be found from:
   {{- if .Values.query.image -}}
     {{- printf "%s" .Values.query.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger:2.10.0" -}}
+    {{- print "jaegertracing/jaeger:2.11.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -182,7 +182,7 @@ Image can be found from:
   {{- if .Values.cassandraSchemaJob.image -}}
     {{- printf "%s" .Values.cassandraSchemaJob.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger-cassandra-schema:1.73.0" -}}
+    {{- print "jaegertracing/jaeger-cassandra-schema:1.74.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -195,7 +195,7 @@ Image can be found from:
   {{- if .Values.hotrod.image -}}
     {{- printf "%s" .Values.hotrod.image -}}
   {{- else -}}
-    {{- print "jaegertracing/example-hotrod:1.73.0" -}}
+    {{- print "jaegertracing/example-hotrod:1.74.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -208,7 +208,7 @@ Image can be found from:
   {{- if .Values.elasticsearch.indexCleaner.image -}}
     {{- printf "%s" .Values.elasticsearch.indexCleaner.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger-es-index-cleaner:1.73.0" -}}
+    {{- print "jaegertracing/jaeger-es-index-cleaner:1.74.0" -}}
   {{- end -}}
 {{- end -}}
 
@@ -221,7 +221,7 @@ Image can be found from:
   {{- if .Values.elasticsearch.rollover.image -}}
     {{- printf "%s" .Values.elasticsearch.rollover.image -}}
   {{- else -}}
-    {{- print "jaegertracing/jaeger-es-rollover:1.73.0" -}}
+    {{- print "jaegertracing/jaeger-es-rollover:1.74.0" -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
# What does this PR do?

Bump the default version of Jaeger components to `2.11.0` (`1.74.0`).