### PR TITLE
feat: add ability to change opensearch parameters using helm

### DIFF
--- a/charts/qubership-jaeger/templates/_helpers.tpl
+++ b/charts/qubership-jaeger/templates/_helpers.tpl
@@ -472,6 +472,186 @@ Return password for OpenSearch/Elasticsearch.
 {{- end -}}
 
 {{/*
+Render index options for Jaeger v2 Elasticsearch/OpenSearch storage.
+*/}}
+{{- define "elasticsearch.runtime.indexOptions" -}}
+{{- $index := . -}}
+{{- if hasKey $index "dateLayout" }}
+date_layout: {{ get $index "dateLayout" | quote }}
+{{- end }}
+{{- if hasKey $index "rolloverFrequency" }}
+rollover_frequency: {{ get $index "rolloverFrequency" | quote }}
+{{- end }}
+{{- if hasKey $index "shards" }}
+shards: {{ get $index "shards" }}
+{{- end }}
+{{- if hasKey $index "replicas" }}
+replicas: {{ get $index "replicas" }}
+{{- end }}
+{{- if hasKey $index "priority" }}
+priority: {{ get $index "priority" }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Render indices section for Jaeger v2 Elasticsearch/OpenSearch storage.
+*/}}
+{{- define "elasticsearch.runtime.indices" -}}
+{{- if .Values.elasticsearch.indexPrefix }}
+index_prefix: {{ .Values.elasticsearch.indexPrefix | quote }}
+{{- end }}
+{{- with .Values.elasticsearch.indices }}
+{{- with .spans }}
+{{- $spans := include "elasticsearch.runtime.indexOptions" . | trim }}
+{{- if $spans }}
+spans:
+{{ $spans | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- with .services }}
+{{- $services := include "elasticsearch.runtime.indexOptions" . | trim }}
+{{- if $services }}
+services:
+{{ $services | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- with .dependencies }}
+{{- $dependencies := include "elasticsearch.runtime.indexOptions" . | trim }}
+{{- if $dependencies }}
+dependencies:
+{{ $dependencies | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- with .sampling }}
+{{- $sampling := include "elasticsearch.runtime.indexOptions" . | trim }}
+{{- if $sampling }}
+sampling:
+{{ $sampling | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Render Jaeger v2 Elasticsearch/OpenSearch runtime storage config.
+*/}}
+{{- define "elasticsearch.runtime.config" -}}
+elasticsearch:
+  server_urls:
+    {{- $url := include "elasticsearch.url" . }}
+    {{- if $url }}
+    - {{ $url | quote }}
+    {{- end }}
+  auth:
+    basic:
+      username: "${env:ES_USERNAME}"
+      password: "${env:ES_PASSWORD}"
+  {{- if hasKey .Values.elasticsearch "remoteReadClusters" }}
+  remote_read_clusters:
+    {{- toYaml .Values.elasticsearch.remoteReadClusters | nindent 4 }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "disableHealthCheck" }}
+  disable_health_check: {{ .Values.elasticsearch.disableHealthCheck }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "sendGetBodyAs" }}
+  send_get_body_as: {{ .Values.elasticsearch.sendGetBodyAs | quote }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "queryTimeout" }}
+  query_timeout: {{ .Values.elasticsearch.queryTimeout | quote }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "httpCompression" }}
+  http_compression: {{ .Values.elasticsearch.httpCompression }}
+  {{- end }}
+  {{- if .Values.elasticsearch.customHeaders }}
+  custom_headers:
+    {{- toYaml .Values.elasticsearch.customHeaders | nindent 4 }}
+  {{- end }}
+  {{- if .Values.elasticsearch.bulkProcessing }}
+  bulk_processing:
+    {{- with .Values.elasticsearch.bulkProcessing.maxBytes }}
+    max_bytes: {{ . }}
+    {{- end }}
+    {{- with .Values.elasticsearch.bulkProcessing.maxActions }}
+    max_actions: {{ . }}
+    {{- end }}
+    {{- with .Values.elasticsearch.bulkProcessing.flushInterval }}
+    flush_interval: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.elasticsearch.bulkProcessing.workers }}
+    workers: {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "version" }}
+  version: {{ .Values.elasticsearch.version }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "logLevel" }}
+  log_level: {{ .Values.elasticsearch.logLevel | quote }}
+  {{- end }}
+  {{- $indices := include "elasticsearch.runtime.indices" . | trim }}
+  {{- if $indices }}
+  indices:
+{{ $indices | nindent 4 }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "useAliases" }}
+  use_aliases: {{ .Values.elasticsearch.useAliases }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "createMappings" }}
+  create_mappings: {{ .Values.elasticsearch.createMappings }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "useIlm" }}
+  use_ilm: {{ .Values.elasticsearch.useIlm }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "maxDocCount" }}
+  max_doc_count: {{ .Values.elasticsearch.maxDocCount }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "maxSpanAge" }}
+  max_span_age: {{ .Values.elasticsearch.maxSpanAge | quote }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "serviceCacheTtl" }}
+  service_cache_ttl: {{ .Values.elasticsearch.serviceCacheTtl | quote }}
+  {{- end }}
+  {{- if hasKey .Values.elasticsearch "adaptiveSamplingLookback" }}
+  adaptive_sampling_lookback: {{ .Values.elasticsearch.adaptiveSamplingLookback | quote }}
+  {{- end }}
+  {{- if .Values.elasticsearch.tagsAsFields }}
+  tags_as_fields:
+    {{- if hasKey .Values.elasticsearch.tagsAsFields "all" }}
+    all: {{ .Values.elasticsearch.tagsAsFields.all }}
+    {{- end }}
+    {{- if hasKey .Values.elasticsearch.tagsAsFields "dotReplacement" }}
+    dot_replacement: {{ .Values.elasticsearch.tagsAsFields.dotReplacement | quote }}
+    {{- end }}
+    {{- if hasKey .Values.elasticsearch.tagsAsFields "configFile" }}
+    config_file: {{ .Values.elasticsearch.tagsAsFields.configFile | quote }}
+    {{- end }}
+    {{- if hasKey .Values.elasticsearch.tagsAsFields "include" }}
+    include: {{ .Values.elasticsearch.tagsAsFields.include | quote }}
+    {{- end }}
+  {{- end }}
+  tls:
+    {{- if .Values.elasticsearch.client.tls.enabled }}
+    {{- if .Values.elasticsearch.client.tls.insecureSkipVerify }}
+    insecure_skip_verify: true
+    {{- else }}
+    ca_file: /es-tls/ca-cert.pem
+    cert_file: /es-tls/client-cert.pem
+    key_file: /es-tls/client-key.pem
+    {{- end }}
+    {{- else }}
+    insecure: true
+    {{- end }}
+  {{- if .Values.elasticsearch.sniffing }}
+  sniffing:
+    {{- if hasKey .Values.elasticsearch.sniffing "enabled" }}
+    enabled: {{ .Values.elasticsearch.sniffing.enabled }}
+    {{- end }}
+    {{- if hasKey .Values.elasticsearch.sniffing "useHttps" }}
+    use_https: {{ .Values.elasticsearch.sniffing.useHttps }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Return securityContext section for Cassandra Schema Job Container
 */}}
 {{- define "cassandraSchemaJob.containerSecurityContext" -}}

--- a/charts/qubership-jaeger/templates/collector/configmap-config.yaml
+++ b/charts/qubership-jaeger/templates/collector/configmap-config.yaml
@@ -115,37 +115,7 @@ data:
                       {{- toYaml .Values.cassandraSchemaJob.allowedAuthenticators | nindent 22 }}
           {{- else if eq .Values.jaeger.storage.type "elasticsearch" }}
           main_elasticsearch:
-            elasticsearch:
-              server_urls:
-                {{ if and .Values.elasticsearch.client.url .Values.elasticsearch.client.scheme }}
-                  {{- printf "- %s://%s" ( .Values.elasticsearch.client.scheme ) ( .Values.elasticsearch.client.url ) -}}
-                {{- else }}
-                  {{- if .Values.INFRA_OPENSEARCH_URL -}}
-                  {{- printf "%s" .Values.INFRA_OPENSEARCH_URL -}}
-                  {{- else -}}
-                  {{- print "" -}}
-                  {{- end -}}
-                {{- end }}
-              auth:
-                basic:
-                  username: "${env:ES_USERNAME}"
-                  password: "${env:ES_PASSWORD}"
-              {{- if .Values.elasticsearch.indexPrefix }}
-              indices:
-                index_prefix: {{ .Values.elasticsearch.indexPrefix | quote }}
-              {{- end }}
-              tls:
-                {{- if .Values.elasticsearch.client.tls.enabled }}
-                {{- if .Values.elasticsearch.client.tls.insecureSkipVerify }}
-                insecure_skip_verify: true
-                {{- else }}
-                ca_file: /es-tls/ca-cert.pem
-                cert_file: /es-tls/client-cert.pem
-                key_file: /es-tls/client-key.pem
-                {{- end}}
-                {{- else }}
-                insecure: true
-                {{- end }}
+            {{- include "elasticsearch.runtime.config" . | nindent 12 }}
           {{- else if eq .Values.jaeger.storage.type "remotegRPC" }}
           remote_grpc:
             grpc:

--- a/charts/qubership-jaeger/templates/collector/deployment.yaml
+++ b/charts/qubership-jaeger/templates/collector/deployment.yaml
@@ -95,6 +95,16 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.elasticsearch.existingSecret | default "jaeger-elasticsearch" }}
                   key: password
+            {{- range $key, $value := .Values.elasticsearch.env }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.elasticsearch.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.collector.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- end }}
           {{- if .Values.readinessProbe.install }}
           livenessProbe:

--- a/charts/qubership-jaeger/templates/query/configmap-config.yaml
+++ b/charts/qubership-jaeger/templates/query/configmap-config.yaml
@@ -131,37 +131,7 @@ data:
                       {{- toYaml .Values.cassandraSchemaJob.allowedAuthenticators | nindent 22 }}
           {{- else if eq .Values.jaeger.storage.type "elasticsearch" }}
           main_elasticsearch:
-            elasticsearch:
-              server_urls:
-                {{ if and .Values.elasticsearch.client.url .Values.elasticsearch.client.scheme }}
-                  {{- printf "- %s://%s" ( .Values.elasticsearch.client.scheme ) ( .Values.elasticsearch.client.url ) -}}
-                {{- else }}
-                  {{- if .Values.INFRA_OPENSEARCH_URL -}}
-                  {{- printf "%s" .Values.INFRA_OPENSEARCH_URL -}}
-                  {{- else -}}
-                  {{- print "" -}}
-                  {{- end -}}
-                {{- end }}
-              auth:
-                basic:
-                  username: "${env:ES_USERNAME}"
-                  password: "${env:ES_PASSWORD}"
-              {{- if .Values.elasticsearch.indexPrefix }}
-              indices:
-                index_prefix: {{ .Values.elasticsearch.indexPrefix | quote }}
-              {{- end }}
-              tls:
-                {{- if .Values.elasticsearch.client.tls.enabled }}
-                {{- if .Values.elasticsearch.client.tls.insecureSkipVerify }}
-                insecure_skip_verify: true
-                {{- else }}
-                ca_file: /es-tls/ca-cert.pem
-                cert_file: /es-tls/client-cert.pem
-                key_file: /es-tls/client-key.pem
-                {{- end }}
-                {{- else }}
-                insecure: true
-                {{- end }}
+            {{- include "elasticsearch.runtime.config" . | nindent 12 }}
           {{- else if eq .Values.jaeger.storage.type "remotegRPC" }}
           remote_grpc:
             grpc:

--- a/charts/qubership-jaeger/templates/query/deployment.yaml
+++ b/charts/qubership-jaeger/templates/query/deployment.yaml
@@ -97,6 +97,12 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- with .Values.elasticsearch.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.query.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if .Values.readinessProbe.install }}
           livenessProbe:

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -1,6 +1,7 @@
 # Default values for jaeger.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+# yamllint disable rule:comments-indentation
 
 jaeger:
   # Name of jaeger service.
@@ -217,7 +218,7 @@ elasticsearch:
   #   configFile: /etc/jaeger/tags-as-fields.yaml
   #   include: http.status_code,error
   #
-  indices:
+  indices: {}
     # spans:
     #   dateLayout: "2006-01-02"
     #   rolloverFrequency: day

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -170,10 +170,81 @@ elasticsearch:
   indexPrefix: ""
 
   # Elasticsearch related extra env vars to be configured on the concerned components.
-  # Type: object
+  # Type: array
   # Default: []
   #
   extraEnv: []
+
+  # Additional Jaeger v2 runtime storage settings for Elasticsearch/OpenSearch.
+  # These fields are optional: if omitted, Jaeger internal defaults are used.
+  #
+  # remoteReadClusters:
+  # - remote-cluster
+  #
+  # disableHealthCheck: true
+  # sendGetBodyAs: GET
+  # queryTimeout: 30s
+  # httpCompression: false
+  #
+  # version: 8
+  # logLevel: debug
+  #
+  # useAliases: true
+  # createMappings: false
+  # useIlm: true
+  #
+  # maxDocCount: 20000
+  # maxSpanAge: 72h
+  # serviceCacheTtl: 1h
+  # adaptiveSamplingLookback: 72h
+  #
+  # customHeaders:
+  #   Host: my-opensearch-domain.example.com
+  #
+  # sniffing:
+  #   enabled: true
+  #   useHttps: true
+  #
+  # bulkProcessing:
+  #   maxBytes: 5000000
+  #   maxActions: 1000
+  #   flushInterval: 200ms
+  #   workers: 1
+  #
+  # tagsAsFields:
+  #   all: true
+  #   dotReplacement: "@"
+  #   configFile: /etc/jaeger/tags-as-fields.yaml
+  #   include: http.status_code,error
+  #
+  indices:
+    # spans:
+    #   dateLayout: "2006-01-02"
+    #   rolloverFrequency: day
+    #   shards: 1
+    #   replicas: 0
+    #   priority: 100
+    #
+    # services:
+    #   dateLayout: "2006-01-02"
+    #   rolloverFrequency: day
+    #   shards: 1
+    #   replicas: 0
+    #   priority: 100
+    #
+    # dependencies:
+    #   dateLayout: "2006-01-02"
+    #   rolloverFrequency: day
+    #   shards: 1
+    #   replicas: 0
+    #   priority: 100
+    #
+    # sampling:
+    #   dateLayout: "2006-01-02"
+    #   rolloverFrequency: day
+    #   shards: 1
+    #   replicas: 0
+    #   priority: 100
 
   client:
     # Username for Elasticsearch with access to HTTP API.

--- a/docs/examples/opensearch.md
+++ b/docs/examples/opensearch.md
@@ -13,7 +13,8 @@ Basic configuration for development environments.
 **Key parameters:**
 - `elasticsearch.client.url` - OpenSearch endpoint
 - `indexCleaner.install: true` - Enables automatic index cleanup
-- `scheme: https` - Secure connection
+- `elasticsearch.client.scheme: https` - Secure connection
+- `elasticsearch.indices.*` - Optional Jaeger v2 runtime index settings
 
 ## OpenSearch with TLS
 
@@ -25,8 +26,8 @@ Secure connection with custom certificates.
 
 **Key parameters:**
 - `tls.enabled: true` - Enables TLS verification
-- `skipHostVerify: false` - Strict certificate validation
-- `tls.secretName` - Kubernetes secret with certificates
+- `insecureSkipVerify: false` - Strict certificate validation
+- `tls.existingSecret` - Kubernetes secret with certificates
 
 ## OpenSearch with Rollover
 
@@ -38,8 +39,8 @@ Automatic index management for large deployments.
 
 **Key parameters:**
 - `indexCleaner.numberOfDays: 7` - Retain 7 days of data
-- `rollover.conditions.maxAge: "1d"` - Daily index rotation
-- `rollover.conditions.maxSize: "10gb"` - Size-based rotation
+- `elasticsearch.useAliases: true` - Enable Jaeger runtime alias usage
+- `elasticsearch.rollover.initHook.extraEnv` - Pass init job env such as `SHARDS` and `REPLICAS`
 
 ## OpenSearch Single Node
 
@@ -50,9 +51,9 @@ Minimal setup for testing.
 ```
 
 **Key parameters:**
-- `scheme: http` - Non-secure connection for testing
-- `indexCleaner.install: false` - Disabled for testing
-- Minimal resource allocation
+- `elasticsearch.indices.*.shards: 1` - Reduce per-index shard count
+- `elasticsearch.indices.*.replicas: 0` - Disable replicas for single node
+- `elasticsearch.rollover.initHook.extraEnv` - Keep rollover init aligned with runtime settings
 
 ## OpenSearch with Insecure TLS
 
@@ -64,7 +65,7 @@ TLS with certificate verification disabled.
 
 **Key parameters:**
 - `tls.enabled: true` - Enables TLS
-- `skipHostVerify: true` - Disables certificate validation
+- `insecureSkipVerify: true` - Disables certificate validation
 - Useful for self-signed certificates
 
 ## OpenSearch with Predefined Secret
@@ -76,7 +77,7 @@ Use existing Kubernetes secret for TLS certificates.
 ```
 
 **Key parameters:**
-- `tls.secretName` - Existing Kubernetes secret
+- `tls.existingSecret` - Existing Kubernetes secret
 - Pre-configured TLS certificates
 - External certificate management
 

--- a/docs/examples/opensearch/opensearch-one-node-values.yaml
+++ b/docs/examples/opensearch/opensearch-one-node-values.yaml
@@ -12,6 +12,20 @@ elasticsearch:
     password: admin
     scheme: https
     url: elasticsearch.elasticsearch.svc:9200
+  useAliases: true
+  indices:
+    spans:
+      shards: 1
+      replicas: 0
+    services:
+      shards: 1
+      replicas: 0
+    dependencies:
+      shards: 1
+      replicas: 0
+    sampling:
+      shards: 1
+      replicas: 0
   rollover:
     install: true
     schedule: "10 0 * * *"
@@ -28,17 +42,9 @@ elasticsearch:
 
 collector:
   install: true
-  extraEnv:
-  # Specify 0 replicas
-  - name: ES_NUM_REPLICAS
-    value: "0"
 
 query:
   install: true
-  extraEnv:
-  # Specify 0 replicas
-  - name: ES_NUM_REPLICAS
-    value: "0"
   ingress:
     install: true
     host: query.<cloud_dns_name>

--- a/docs/examples/opensearch/opensearch-simple-values.yaml
+++ b/docs/examples/opensearch/opensearch-simple-values.yaml
@@ -12,6 +12,14 @@ elasticsearch:
     password: ...replace by password...
     scheme: https
     url: opensearch.opensearch.svc:9200
+  # Optional Jaeger v2 runtime storage tuning:
+  # indices:
+  #   spans:
+  #     shards: 1
+  #     replicas: 0
+  #   services:
+  #     shards: 1
+  #     replicas: 0
   indexCleaner:
     install: true
 


### PR DESCRIPTION
[issue](https://github.com/Netcracker/qubership-jaeger/issues/300)
Manual commands for test new parameters:
0) Prerequisite: installed cert-manager
1) Install opensearch:
```
helm install opensearch opensearch/opensearch `
  --namespace jaeger `
  --create-namespace `
  --set singleNode=true `
  --set persistence.enabled=false `
  --set extraEnvs[0].name=OPENSEARCH_INITIAL_ADMIN_PASSWORD `
  --set-string extraEnvs[0].value=TraceStore!2026 `
  --set resources.requests.cpu=200m `
  --set resources.requests.memory=1Gi `
  --set opensearchJavaOpts=-Xms512M\ -Xmx512M `
```
2) Install jaeger with all opensearch parameters
```
helm install jaeger charts/qubership-jaeger \
  --namespace jaeger \
  --set jaeger.prometheusMonitoring=false \
  --set jaeger.prometheusMonitoringDashboard=false \
  --set jaeger.storage.type=elasticsearch \
  --set elasticsearch.client.username=admin \
  --set-string elasticsearch.client.password='TraceStore!2026' \
  --set elasticsearch.client.scheme=https \
  --set elasticsearch.client.url=opensearch-cluster-master:9200 \
  --set elasticsearch.client.tls.enabled=true \
  --set elasticsearch.client.tls.insecureSkipVerify=true \
  --set elasticsearch.indexPrefix=jaeger \
  --set elasticsearch.useAliases=true \
  --set elasticsearch.createMappings=false \
  --set elasticsearch.useIlm=false \
  --set elasticsearch.disableHealthCheck=true \
  --set-string elasticsearch.sendGetBodyAs=GET \
  --set-string elasticsearch.queryTimeout=30s \
  --set elasticsearch.httpCompression=false \
  --set elasticsearch.logLevel=error \
  --set elasticsearch.version=0 \
  --set elasticsearch.maxDocCount=5000 \
  --set-string elasticsearch.maxSpanAge=24h \
  --set-string elasticsearch.serviceCacheTtl=1h \
  --set-string elasticsearch.adaptiveSamplingLookback=48h \
  --set elasticsearch.sniffing.enabled=false \
  --set elasticsearch.sniffing.useHttps=true \
  --set elasticsearch.bulkProcessing.maxBytes=6000000 \
  --set elasticsearch.bulkProcessing.maxActions=500 \
  --set-string elasticsearch.bulkProcessing.flushInterval=500ms \
  --set elasticsearch.bulkProcessing.workers=2 \
  --set elasticsearch.tagsAsFields.all=true \
  --set-string elasticsearch.tagsAsFields.dotReplacement='_' \
  --set elasticsearch.remoteReadClusters[0]=remote-a \
  --set elasticsearch.customHeaders.X-Test=runtime \
  --set elasticsearch.indices.spans.shards=1 \
  --set elasticsearch.indices.spans.replicas=0 \
  --set elasticsearch.indices.spans.priority=100 \
  --set-string elasticsearch.indices.spans.dateLayout=2006-01-02 \
  --set elasticsearch.indices.spans.rolloverFrequency=day \
  --set elasticsearch.indices.services.shards=1 \
  --set elasticsearch.indices.services.replicas=0 \
  --set elasticsearch.indices.services.priority=100 \
  --set-string elasticsearch.indices.services.dateLayout=2006-01-02 \
  --set elasticsearch.indices.services.rolloverFrequency=day \
  --set elasticsearch.indices.dependencies.shards=1 \
  --set elasticsearch.indices.dependencies.replicas=0 \
  --set elasticsearch.indices.dependencies.priority=100 \
  --set-string elasticsearch.indices.dependencies.dateLayout=2006-01-02 \
  --set elasticsearch.indices.dependencies.rolloverFrequency=day \
  --set elasticsearch.indices.sampling.shards=1 \
  --set elasticsearch.indices.sampling.replicas=0 \
  --set elasticsearch.indices.sampling.priority=100 \
  --set-string elasticsearch.indices.sampling.dateLayout=2006-01-02 \
  --set elasticsearch.indices.sampling.rolloverFrequency=day \
  --set elasticsearch.extraEnv[0].name=GLOBAL_TEST \
  --set-string elasticsearch.extraEnv[0].value=1 \
  --set elasticsearch.env.LEGACY_TEST=1 \
  --set collector.extraEnv[0].name=COLLECTOR_TEST \
  --set-string collector.extraEnv[0].value=1 \
  --set query.extraEnv[0].name=QUERY_TEST \
  --set-string query.extraEnv[0].value=1 \
  --set elasticsearch.rollover.install=true \
  --set elasticsearch.rollover.schedule='10 0 * * *' \
  --set elasticsearch.rollover.initHook.extraEnv[0].name=REPLICAS \
  --set-string elasticsearch.rollover.initHook.extraEnv[0].value=0 \
  --set elasticsearch.rollover.initHook.extraEnv[1].name=SHARDS \
  --set-string elasticsearch.rollover.initHook.extraEnv[1].value=1 \
  --set elasticsearch.lookback.install=false \
  --set elasticsearch.indexCleaner.install=false"
```