### PR TITLE
docs: fix Gateway API documentation link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -515,7 +515,7 @@ exposed either with `HTTPRoute` or with native `GRPCRoute`, depending on the val
 `collector.gatewayApi.grpcRoute.kind`.
 
 TLS termination is configured on the Gateway listener. To bind a route to a specific listener, use
-`parentRefs[].sectionName`. More info in [Attaching to gateways](https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways).
+`parentRefs[].sectionName`. More info in [Attaching to gateways](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#attaching-to-gateways).
 
 ```yaml
 collector:


### PR DESCRIPTION
Closes #326

Updated the Gateway API HTTPRoute documentation link in docs/installation.md to the current reference URL.

Verification:
- curl -I -L https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#attaching-to-gateways returns HTTP/2 200
- git diff --check
- pre-commit hooks during commit