### PR TITLE
fix: add default backendRef fields to HTTPRoute templates

### DIFF
--- a/charts/qubership-jaeger/templates/_helpers.tpl
+++ b/charts/qubership-jaeger/templates/_helpers.tpl
@@ -127,8 +127,11 @@ Render shared HTTPRoute rules.
           replacePrefixMatch: {{ .rewritePrefix | quote }}
   {{- end }}
   backendRefs:
-    - name: {{ coalesce .service.name $defaultServiceName }}
+    - group: ""
+      kind: Service
+      name: {{ coalesce .service.name $defaultServiceName }}
       port: {{ .service.port }}
+      weight: 1
 {{- end -}}
 {{- end -}}
 

--- a/charts/qubership-jaeger/templates/collector/grpcroute.yaml
+++ b/charts/qubership-jaeger/templates/collector/grpcroute.yaml
@@ -2,7 +2,7 @@
 {{- $grpcRouteSpec := $gatewayApi.grpcRoute | default dict -}}
 {{- $parentRefs := $grpcRouteSpec.parentRefs | default list -}}
 {{- $hostnames := $grpcRouteSpec.hosts | default list -}}
-{{- $defaultRules := list (dict "backendRefs" (list (dict "name" (printf "%s-collector" $.Values.jaeger.serviceName) "port" 4317))) -}}
+{{- $defaultRules := list (dict "backendRefs" (list (dict "group" "" "kind" "Service" "name" (printf "%s-collector" $.Values.jaeger.serviceName) "port" 4317 "weight" 1))) -}}
 {{- $rules := $grpcRouteSpec.rules | default $defaultRules -}}
 {{- if and .Values.collector.install ($grpcRouteSpec.install | default false) (eq ($grpcRouteSpec.kind | default "HTTPRoute") "GRPCRoute") }}
 {{- $resourceName := include "collector.httpRoute.resourceName" (list $ "grpc") }}

--- a/charts/qubership-jaeger/templates/hotrod/httproute.yaml
+++ b/charts/qubership-jaeger/templates/hotrod/httproute.yaml
@@ -36,6 +36,9 @@ spec:
             type: PathPrefix
             value: "/"
       backendRefs:
-        - name: {{ .Values.jaeger.serviceName }}-hotrod
+        - group: ""
+          kind: Service
+          name: {{ .Values.jaeger.serviceName }}-hotrod
           port: {{ .Values.hotrod.service.port }}
+          weight: 1
 {{- end }}

--- a/charts/qubership-jaeger/templates/query/httproute.yaml
+++ b/charts/qubership-jaeger/templates/query/httproute.yaml
@@ -36,6 +36,9 @@ spec:
             type: PathPrefix
             value: "/"
       backendRefs:
-        - name: {{ $name }}
+        - group: ""
+          kind: Service
+          name: {{ $name }}
           port: 16686
+          weight: 1
 {{- end }}


### PR DESCRIPTION
Explicitly set group, kind, and weight on HTTPRoute backendRefs to match
Gateway API server defaults and prevent ArgoCD OutOfSync drift.

issue: https://github.com/Netcracker/qubership-jaeger/issues/347