### PR TITLE
chore(deps): use shared Renovate config

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,27 @@
+name: Validate Renovate Config
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -15,6 +15,9 @@ jobs:
   validate-renovate-config:
     name: Validate renovate.json
     runs-on: ubuntu-latest
+    container:
+      image: renovate/renovate:43.285.4@sha256:bd7d8f646bf9d22aea995eaad06ec26c3f4fd4efbc36826024f5653006c9e7b1
+      options: --user 0
     permissions:
       contents: read
     steps:
@@ -24,4 +27,24 @@ jobs:
           persist-credentials: false
 
       - name: Validate renovate.json
-        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json
+        run: renovate-config-validator --strict --no-global renovate.json
+
+      - name: Resolve shared Renovate presets
+        shell: bash
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          LOG_FORMAT: json
+          LOG_LEVEL: warn
+        run: |
+          set -o pipefail
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+          validation_filter='fromjson? | select(.err.validationError? or .msg == "Repository has invalid config")'
+
+          renovate --platform=local --dry-run=extract 2>&1 | tee "$log_file"
+
+          if jq -R -e "$validation_filter" "$log_file" >/dev/null; then
+            echo "::error::Renovate could not resolve the repository configuration"
+            jq -R -r "$validation_filter | .err.validationError // .msg" "$log_file"
+            exit 1
+          fi

--- a/agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/references/troubleshooting.md
+++ b/agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/references/troubleshooting.md
@@ -106,7 +106,6 @@ labels and annotations that mark it as belonging to this release.
 
 **Sources:**
 
-* [Helm not creating the resources — Stack Overflow](https://stackoverflow.com/questions/62964532)
 * [Adopt resources into a release — helm/helm#7649](https://github.com/helm/helm/pull/7649)
 
 ### Helm install fails with `Invalid duration format`

--- a/docs/troubleshooting.superseded.md
+++ b/docs/troubleshooting.superseded.md
@@ -79,8 +79,8 @@ If services support migration to new Kubernetes the correct way to upgrade it is
 
 Helm doesn't allow a resource to be owned by more than one deployment. During jaeger upgrade it's possible you create
 resources that already existed and created outside of Helm. In such cases you may see error related to labels and
-annotation validation. For more details please refer
-[article](https://stackoverflow.com/questions/62964532/helm-not-creating-the-resources)
+annotation validation. For more details, see
+[Adopt resources into a release](https://github.com/helm/helm/pull/7649).
 
 **Solution**
 

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,20 @@
   "prConcurrentLimit": 20,
   "packageRules": [
     {
+      "description": "Other Go modules",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchPackageNames": [
+        "!k8s.io/**",
+        "!sigs.k8s.io/**",
+        "!github.com/openshift/**",
+        "!go.opentelemetry.io/**",
+        "!github.com/open-telemetry/**",
+        "!github.com/prometheus/**"
+      ],
+      "groupName": "go-deps"
+    },
+    {
       "description": "Third-party Docker images",
       "matchManagers": ["dockerfile"],
       "groupName": "docker-deps",

--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,6 @@
     "github>Netcracker/renovate-config:go",
     "github>Netcracker/renovate-config:netcracker-dependencies"
   ],
-  "schedule": [
-    "* * * * 0"
-  ],
   "prConcurrentLimit": 20,
   "packageRules": [
     {
@@ -30,7 +27,13 @@
       "description": "Third-party Docker images",
       "matchManagers": ["dockerfile"],
       "groupName": "docker-deps",
-      "matchPackageNames": ["!ghcr.io/netcracker/**"]
+      "matchPackageNames": [
+        "!ghcr.io/netcracker/**",
+        "!golang",
+        "!docker.io/library/golang",
+        "!index.docker.io/library/golang",
+        "!registry-1.docker.io/library/golang"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
         "!github.com/openshift/**",
         "!go.opentelemetry.io/**",
         "!github.com/open-telemetry/**",
-        "!github.com/prometheus/**"
+        "!github.com/prometheus/**",
+        "!github.com/Netcracker/**"
       ],
       "groupName": "go-deps"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -4,25 +4,11 @@
     "github>Netcracker/renovate-config:base",
     "github>Netcracker/renovate-config:github-actions",
     "github>Netcracker/renovate-config:go",
-    "github>Netcracker/renovate-config:netcracker-dependencies"
+    "github>Netcracker/renovate-config:netcracker-dependencies",
+    "github>Netcracker/renovate-config:go-catch-all"
   ],
   "prConcurrentLimit": 20,
   "packageRules": [
-    {
-      "description": "Other Go modules",
-      "matchManagers": ["gomod"],
-      "matchDatasources": ["go"],
-      "matchPackageNames": [
-        "!k8s.io/**",
-        "!sigs.k8s.io/**",
-        "!github.com/openshift/**",
-        "!go.opentelemetry.io/**",
-        "!github.com/open-telemetry/**",
-        "!github.com/prometheus/**",
-        "!github.com/Netcracker/**"
-      ],
-      "groupName": "go-deps"
-    },
     {
       "description": "Third-party Docker images",
       "matchManagers": ["dockerfile"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,48 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "schedule:weekly"
+    "github>Netcracker/renovate-config:base",
+    "github>Netcracker/renovate-config:github-actions",
+    "github>Netcracker/renovate-config:go",
+    "github>Netcracker/renovate-config:netcracker-dependencies"
   ],
-  "labels": [
-    "dependencies"
+  "schedule": [
+    "* * * * 0"
   ],
   "prConcurrentLimit": 20,
   "packageRules": [
     {
-      "description": "All GitHub Actions",
-      "matchManagers": ["github-actions"],
-      "groupName": "actions-deps"
-    },
-    {
-      "description": "Netcracker GitHub Actions and reusable workflows",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
-      "groupName": "netcracker-github-actions",
-      "separateMajorMinor": false
-    },
-    {
-      "description": "All 3rd party Docker images",
+      "description": "Third-party Docker images",
       "matchManagers": ["dockerfile"],
-      "groupName": "docker-deps"
-    },
-    {
-      "description": "Netcracker Docker images",
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["ghcr.io/netcracker/**"],
-      "groupName": "netcracker-docker-images",
-      "separateMajorMinor": false
-    },
-    {
-      "description": "All other Go dependencies",
-      "matchManagers": ["gomod"],
-      "groupName": "go-deps"
-    },
-    {
-      "description": "Kubernetes-related Go modules",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"],
-      "groupName": "go-k8s"
+      "groupName": "docker-deps",
+      "matchPackageNames": ["!ghcr.io/netcracker/**"]
     }
   ]
 }


### PR DESCRIPTION
## Why

Copied dependency groups can drift from the organization Renovate policy.

## What

- Use the shared base, GitHub Actions, Go, Go catch-all, and Netcracker dependency presets.
- Preserve repository-specific third-party Docker grouping and PR concurrency.
- Inherit the shared weekly update schedule.
- Replace Stack Overflow references that reject automated link checks.
- Validate `renovate.json` in CI.

Related shared configuration: [Netcracker/renovate-config#29](https://github.com/Netcracker/renovate-config/pull/29), [Netcracker/renovate-config#31](https://github.com/Netcracker/renovate-config/pull/31), and [Netcracker/renovate-config#36](https://github.com/Netcracker/renovate-config/pull/36).
