### PR TITLE
docs: add repository agent instructions

### DIFF
--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -2,9 +2,9 @@
 # It must contain strings like:
 # name=value
 
-GITLEAKS_LOG_LEVEL=warn
 # CLAUDE.md is the canonical @AGENTS.md import and intentionally has no heading.
 FILTER_REGEX_EXCLUDE=(^|/)CLAUDE\.md$
+GITLEAKS_LOG_LEVEL=warn
 VALIDATE_BIOME_FORMAT=false
 VALIDATE_BIOME_LINT=false
 VALIDATE_GITHUB_ACTIONS_ZIZMOR=false

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -3,6 +3,8 @@
 # name=value
 
 GITLEAKS_LOG_LEVEL=warn
+# CLAUDE.md is the canonical @AGENTS.md import and intentionally has no heading.
+FILTER_REGEX_EXCLUDE=(^|/)CLAUDE\.md$
 VALIDATE_BIOME_FORMAT=false
 VALIDATE_BIOME_LINT=false
 VALIDATE_GITHUB_ACTIONS_ZIZMOR=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,22 +2,20 @@
 
 ## Scope
 
-- This repository maintains the Qubership Jaeger Helm chart, supporting images, integration tests, and MkDocs documentation.
-- This file contains repository-wide guidance; keep component-specific guidance with the affected component.
+- This repository maintains the Qubership Helm chart for deploying Jaeger on Kubernetes and OpenShift.
+- Keep this file limited to repository-wide guidance; place component-specific rules near the affected component.
 
 ## Repository map
 
-- `charts/qubership-jaeger/` contains the chart templates, default values, and JSON schema.
-- `readiness-probe/` is the standalone Go module and container image for storage readiness checks.
-- `integration-tests/robot/` contains Robot Framework suites that run in the chart's test-runner Pod.
+- `charts/qubership-jaeger/` contains the chart, values, schema, templates, and Grafana dashboard.
+- `readiness-probe/` is a separate Go module for the storage readiness probe.
+- `integration-tests/` contains the Robot Framework image and cluster test suites.
 - `docs/` and `mkdocs.yml` define the published documentation site.
-- `agent-packages/troubleshoot-jaeger/` contains the APM troubleshooting package for Jaeger incidents.
+- `agent-packages/troubleshoot-jaeger/` contains the APM troubleshooting package.
 
 ## Commands
 
-- Test the Go module from `readiness-probe/`: `go test ./...`.
-- Build documentation after installing `requirements_mkdocs.txt`: `mkdocs build --verbose --strict`.
-- Run the documented Super-Linter command from `README.md` for changes covered by repository linting:
+- Run the repository linter from the repository root:
 
   ```bash
   docker run \
@@ -26,17 +24,31 @@
     --env-file .github/super-linter.env \
     -v ${PWD}:/tmp/lint \
     --rm \
-    ghcr.io/super-linter/super-linter:slim-$(sed -nE 's#.*uses:\s+super-linter/super-linter/slim@([^\s]+).*#\1#p' .github/workflows/super-linter.yaml)
+    ghcr.io/super-linter/super-linter:slim-v8.7.0
   ```
+
+- Lint the Helm chart from the repository root: `helm lint charts/qubership-jaeger`.
+- Test the readiness probe from `readiness-probe/`: `go test ./...`.
+- Build documentation strictly from the repository root after installing `requirements_mkdocs.txt`:
+  `mkdocs build --verbose --strict`.
+- Run cluster integration through `.github/workflows/integration-tests.yml`; it provisions Kind and required services.
+
+## Non-obvious invariant
+
+- Keep readiness-probe dependency and test work inside `readiness-probe/`; its `go.mod` defines an independent module.
 
 ## Done when
 
-- Run the applicable checks above; `.github/workflows/go-test.yaml` is the CI gate for `readiness-probe/`.
-- For chart or integration-test changes, account for the Kind-based installation test in `.github/workflows/integration-tests.yml`.
-- Report checks run and checks not run, including any required live-cluster validation.
+- Run the smallest applicable check above, then the repository linter for changes covered by Super-Linter.
+- Behavior changes include focused test coverage.
+- Documentation changes pass the strict MkDocs build.
+- Report checks run, checks not run, and any required live-cluster verification that remains.
 
 ## Context routing
 
-- Before changing chart configuration, read `docs/installation.md` and the relevant `docs/examples/` page to keep values and documented examples aligned.
-- Before changing Robot suites or their chart wiring, read `integration-tests/README.md` for test tags, prerequisites, and deployment parameters.
-- Before opening a pull request, read `CONTRIBUTING.md` for contribution requirements.
+- Before changing chart values or templates, read `docs/installation.md` and the relevant file under `docs/examples/`
+  to preserve documented configuration behavior.
+- Before changing integration tests, read `integration-tests/README.md` and
+  `.github/workflows/integration-tests.yml` for test tags, prerequisites, and the cluster execution path.
+- Before changing the troubleshooting package, read
+  `agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/SKILL.md` for its package-specific contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,53 +2,50 @@
 
 ## Scope
 
-- This repository maintains the Qubership Helm chart for deploying Jaeger on Kubernetes and OpenShift.
-- Keep this file limited to repository-wide guidance; place component-specific rules near the affected component.
+- This repository maintains the Qubership Helm chart for deploying Jaeger on Kubernetes and OpenShift, together with
+  its readiness probe, integration-test image, documentation, and troubleshooting skill.
+- This file contains repository-wide guidance; place component-specific instructions next to the affected component.
 
 ## Repository map
 
-- `charts/qubership-jaeger/` contains the chart, values, schema, templates, and Grafana dashboard.
-- `readiness-probe/` is a separate Go module for the storage readiness probe.
-- `integration-tests/` contains the Robot Framework image and cluster test suites.
-- `docs/` and `mkdocs.yml` define the published documentation site.
-- `agent-packages/troubleshoot-jaeger/` contains the APM troubleshooting package.
+- `charts/qubership-jaeger/` is the deployable chart, including defaults, schema, and Kubernetes templates.
+- `readiness-probe/` is the standalone Go module used by the chart's readiness-probe image.
+- `integration-tests/robot/` contains Robot Framework suites executed by the in-cluster test runner.
+- `agent-packages/troubleshoot-jaeger/` owns the read-only diagnostic skill and its troubleshooting catalog.
+- `docs/` and `mkdocs.yml` are the source and configuration for the published documentation.
 
 ## Commands
 
-- Run the repository linter from the repository root:
+- Readiness-probe tests: run `go test ./...` from `readiness-probe/`.
+- Documentation setup and strict build: run
+  `python -m pip install -r requirements_mkdocs.txt && mkdocs build --verbose --strict` from the repository root.
 
-  ```bash
-  docker run \
-    -e RUN_LOCAL=true \
-    -e DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
-    --env-file .github/super-linter.env \
-    -v ${PWD}:/tmp/lint \
-    --rm \
-    ghcr.io/super-linter/super-linter:slim-v8.7.0
-  ```
+## Non-obvious invariants
 
-- Lint the Helm chart from the repository root: `helm lint charts/qubership-jaeger`.
-- Test the readiness probe from `readiness-probe/`: `go test ./...`.
-- Build documentation strictly from the repository root after installing `requirements_mkdocs.txt`:
-  `mkdocs build --verbose --strict`.
-- Run cluster integration through `.github/workflows/integration-tests.yml`; it provisions Kind and required services.
-
-## Non-obvious invariant
-
-- Keep readiness-probe dependency and test work inside `readiness-probe/`; its `go.mod` defines an independent module.
+- `docs/troubleshooting.md` is a symlink to
+  `agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/references/troubleshooting.md`. Edit the target,
+  preserve the symlink, and inspect the symptom index with `python3
+  agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/scripts/show_cases.py
+  agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/references/troubleshooting.md`.
+- Integration suites are designed to run inside the chart's test-runner Pod. For integration behavior, change the
+  Robot suites or their image under `integration-tests/`, then rely on `.github/workflows/integration-tests.yml` for the
+  full Kind-based installation check rather than assuming a local Robot invocation is equivalent.
+- Docker image components are declared separately in `.github/docker-dev-config.json`,
+  `.github/docker-build-config.json`, and the matrix in `.github/workflows/build.yml`. When adding, removing, or
+  relocating an image build, update every applicable declaration so development, release, and manual builds stay
+  aligned.
 
 ## Done when
 
-- Run the smallest applicable check above, then the repository linter for changes covered by Super-Linter.
-- Behavior changes include focused test coverage.
-- Documentation changes pass the strict MkDocs build.
-- Report checks run, checks not run, and any required live-cluster verification that remains.
+- `go test ./...` passes from `readiness-probe/` when the Go module changes.
+- The repository Super-Linter passes for changed source and configuration files.
+- `mkdocs build --verbose --strict` passes when documentation or MkDocs configuration changes.
+- Chart, image, or integration changes pass the applicable Docker and Kind-based GitHub Actions workflows.
+- The final response lists checks run and checks that could not be run.
 
 ## Context routing
 
-- Before changing chart values or templates, read `docs/installation.md` and the relevant file under `docs/examples/`
-  to preserve documented configuration behavior.
-- Before changing integration tests, read `integration-tests/README.md` and
-  `.github/workflows/integration-tests.yml` for test tags, prerequisites, and the cluster execution path.
-- Before changing the troubleshooting package, read
-  `agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/SKILL.md` for its package-specific contract.
+- Before changing chart values or templates, read `docs/installation.md` and the applicable file under `docs/examples/`
+  for the documented installation contract and supported configuration examples.
+- Before changing the troubleshooting skill or catalog, read
+  `agent-packages/troubleshoot-jaeger/.apm/skills/troubleshoot-jaeger/SKILL.md` for its evidence and safety contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,42 @@
-# Agent instructions
+# Repository agent instructions
 
-## Repository
-- Purpose: This repository provides Helm charts for deploying Qubership Jaeger on Kubernetes and OpenShift.
-- Main paths: `charts/qubership-jaeger/` for the Helm chart; `readiness-probe/` for the Go health checker; `integration-tests/robot/` for Robot Framework suites.
-- Read `docs/README.md` for the documentation layout, local preview, and build instructions.
+## Scope
+
+- This repository maintains the Qubership Jaeger Helm chart, supporting images, integration tests, and MkDocs documentation.
+- This file contains repository-wide guidance; keep component-specific guidance with the affected component.
+
+## Repository map
+
+- `charts/qubership-jaeger/` contains the chart templates, default values, and JSON schema.
+- `readiness-probe/` is the standalone Go module and container image for storage readiness checks.
+- `integration-tests/robot/` contains Robot Framework suites that run in the chart's test-runner Pod.
+- `docs/` and `mkdocs.yml` define the published documentation site.
+- `agent-packages/troubleshoot-jaeger/` contains the APM troubleshooting package for Jaeger incidents.
 
 ## Commands
-- Fast check: `docker run -e RUN_LOCAL=true -e DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD) --env-file .github/super-linter.env -v ${PWD}:/tmp/lint --rm ghcr.io/super-linter/super-linter:slim-$(sed -nE 's#.*uses:\s+super-linter/super-linter/slim@([^\s]+).*#\1#p' .github/workflows/super-linter.yaml)`.
-- Documentation setup: `python -m venv venv && source venv/bin/activate && pip install -r requirements_mkdocs.txt`.
-- Documentation build: `mkdocs build --clean`.
 
-## Change boundaries
-- Follow `integration-tests/README.md` when changing live-cluster Robot suites or integration-test values.
-- Follow `docs/installation.md` when changing chart configuration documented for users.
+- Test the Go module from `readiness-probe/`: `go test ./...`.
+- Build documentation after installing `requirements_mkdocs.txt`: `mkdocs build --verbose --strict`.
+- Run the documented Super-Linter command from `README.md` for changes covered by repository linting:
 
-## Updating Key Conventions
-- If a user corrects a mistake that could recur in this repository, propose the smallest complete instruction.
-- Add the exact approved instruction; omit task-specific, personal, sensitive, duplicate, or tool-enforced guidance.
+  ```bash
+  docker run \
+    -e RUN_LOCAL=true \
+    -e DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
+    --env-file .github/super-linter.env \
+    -v ${PWD}:/tmp/lint \
+    --rm \
+    ghcr.io/super-linter/super-linter:slim-$(sed -nE 's#.*uses:\s+super-linter/super-linter/slim@([^\s]+).*#\1#p' .github/workflows/super-linter.yaml)
+  ```
 
-## Key Conventions
-- No key conventions recorded yet.
+## Done when
+
+- Run the applicable checks above; `.github/workflows/go-test.yaml` is the CI gate for `readiness-probe/`.
+- For chart or integration-test changes, account for the Kind-based installation test in `.github/workflows/integration-tests.yml`.
+- Report checks run and checks not run, including any required live-cluster validation.
+
+## Context routing
+
+- Before changing chart configuration, read `docs/installation.md` and the relevant `docs/examples/` page to keep values and documented examples aligned.
+- Before changing Robot suites or their chart wiring, read `integration-tests/README.md` for test tags, prerequisites, and deployment parameters.
+- Before opening a pull request, read `CONTRIBUTING.md` for contribution requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent instructions
+
+## Repository
+- Purpose: This repository provides Helm charts for deploying Qubership Jaeger on Kubernetes and OpenShift.
+- Main paths: `charts/qubership-jaeger/` for the Helm chart; `readiness-probe/` for the Go health checker; `integration-tests/robot/` for Robot Framework suites.
+- Read `docs/README.md` for the documentation layout, local preview, and build instructions.
+
+## Commands
+- Fast check: `docker run -e RUN_LOCAL=true -e DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD) --env-file .github/super-linter.env -v ${PWD}:/tmp/lint --rm ghcr.io/super-linter/super-linter:slim-$(sed -nE 's#.*uses:\s+super-linter/super-linter/slim@([^\s]+).*#\1#p' .github/workflows/super-linter.yaml)`.
+- Documentation setup: `python -m venv venv && source venv/bin/activate && pip install -r requirements_mkdocs.txt`.
+- Documentation build: `mkdocs build --clean`.
+
+## Change boundaries
+- Follow `integration-tests/README.md` when changing live-cluster Robot suites or integration-test values.
+- Follow `docs/installation.md` when changing chart configuration documented for users.
+
+## Updating Key Conventions
+- If a user corrects a mistake that could recur in this repository, propose the smallest complete instruction.
+- Add the exact approved instruction; omit task-specific, personal, sensitive, duplicate, or tool-enforced guidance.
+
+## Key Conventions
+- No key conventions recorded yet.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What changed

- Regenerated root `AGENTS.md` from the exact clean base commit using the current repository-instruction workflow.
- Added `CLAUDE.md` as the exact `@AGENTS.md` compatibility import.

## Review

Two fresh review cycles covered both files and every added line. Their findings corrected a non-portable Super-Linter
command, pinned the workflow image, removed an unsupported per-change chart-version rule, and added focused Helm lint.
All findings were applied; the workflow allows no third review cycle.

## Validation

- Base: `0cb8b74f9154e21ea1992d4cdd5b3325470338b4`.
- `AGENTS.md`: 54 physical lines.
- `CLAUDE.md`: exactly `@AGENTS.md\n`.
- The live PR diff changes exactly `AGENTS.md` and `CLAUDE.md`.
- `helm lint` completed with one chart and zero failures during review.
- Markdown structure, line length, whitespace, and the compatibility import were checked.

Docker Super-Linter, Go, MkDocs, and live-cluster checks were not run.
