### PR TITLE
fix: ArgoCD strategic merge patch error and empty sections in rendered manifests

### DIFF
--- a/charts/qubership-jaeger/templates/_helpers.tpl
+++ b/charts/qubership-jaeger/templates/_helpers.tpl
@@ -1588,6 +1588,26 @@ Generate list of args for collector
 {{- end -}}
 
 {{/*
+Generate list of env variables for collector.
+Returns an empty string when there is nothing to render, so the caller can omit
+the "env:" key entirely instead of emitting an empty section.
+*/}}
+{{- define "collector.env" -}}
+{{- if eq .Values.jaeger.storage.type "elasticsearch" }}
+  {{- range $key, $value := .Values.elasticsearch.env }}
+- name: {{ $key | quote }}
+  value: {{ $value | quote }}
+  {{- end }}
+  {{- with .Values.elasticsearch.extraEnv }}
+    {{- toYaml . | nindent 0 }}
+  {{- end }}
+{{- end }}
+{{- with .Values.collector.extraEnv }}
+  {{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Generate certificate volumes for TLS configuration
 */}}
 {{- define "jaeger.certificateVolumes" -}}

--- a/charts/qubership-jaeger/templates/collector/deployment.yaml
+++ b/charts/qubership-jaeger/templates/collector/deployment.yaml
@@ -69,19 +69,10 @@ spec:
           imagePullPolicy: {{ .Values.collector.imagePullPolicy }}
           args:
             {{- template "collector.args" . }}
+          {{- with (include "collector.env" . | trim) }}
           env:
-            {{- if eq .Values.jaeger.storage.type "elasticsearch" }}
-            {{- range $key, $value := .Values.elasticsearch.env }}
-            - name: {{ $key | quote }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- with .Values.elasticsearch.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- end }}
-            {{- with .Values.collector.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .Values.readinessProbe.install }}
           livenessProbe:
             failureThreshold: 3
@@ -153,10 +144,12 @@ spec:
             - name: sampling-config
               mountPath: /etc/jaeger/sampling
               readOnly: true
-            - name: collector-config
+            - name: collector-runtime-config
               mountPath: /conf
               readOnly: true
-            {{- include "jaeger.certificateVolumeMounts" . | nindent 12 }}
+            {{- with (include "jaeger.certificateVolumeMounts" . | trim) }}
+            {{- . | nindent 12 }}
+            {{- end }}
         {{- if .Values.readinessProbe.install }}
         - name: probe
           image: {{ template "readiness-probe.image" . }}
@@ -191,8 +184,10 @@ spec:
             {{- toYaml .Values.readinessProbe.resources | nindent 12 }}
           securityContext:
             {{- include "readinessProbe.containerSecurityContext" . }}
+          {{- with (include "jaeger.certificateVolumeMounts" . | trim) }}
           volumeMounts:
-            {{- include "jaeger.certificateVolumeMounts" . | nindent 12 }}
+            {{- . | nindent 12 }}
+          {{- end }}
         {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
@@ -206,14 +201,16 @@ spec:
             items:
               - key: sampling
                 path: sampling.json
-        - name: collector-config
+        - name: collector-runtime-config
           secret:
             secretName: {{ include "collector.runtimeConfig.secretName" . }}
             items:
               - key: {{ include "collector.runtimeConfig.key" . }}
                 path: config.yaml
             defaultMode: 420
-        {{- include "jaeger.certificateVolumes" . | nindent 8 }}
+        {{- with (include "jaeger.certificateVolumes" . | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       {{- if .Values.collector.affinity }}
       affinity:
         {{- toYaml .Values.collector.affinity | nindent 8 }}

--- a/charts/qubership-jaeger/templates/query/deployment.yaml
+++ b/charts/qubership-jaeger/templates/query/deployment.yaml
@@ -136,10 +136,12 @@ spec:
             - name: ui-config
               mountPath: /etc/config
               readOnly: true
-            - name: query-config
+            - name: query-runtime-config
               mountPath: /conf
               readOnly: true
-            {{- include "jaeger.certificateVolumeMounts" . | nindent 12 }}
+            {{- with (include "jaeger.certificateVolumeMounts" . | trim) }}
+            {{- . | nindent 12 }}
+            {{- end }}
         {{- if .Values.proxy.install }}
         - name: proxy
           image: {{ include "proxy.image" . }}
@@ -228,8 +230,10 @@ spec:
             {{- toYaml .Values.readinessProbe.resources | nindent 12 }}
           securityContext:
             {{- include "readinessProbe.containerSecurityContext" . }}
+          {{- with (include "jaeger.certificateVolumeMounts" . | trim) }}
           volumeMounts:
-            {{- include "jaeger.certificateVolumeMounts" . | nindent 12 }}
+            {{- . | nindent 12 }}
+          {{- end }}
         {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
@@ -242,7 +246,7 @@ spec:
           configMap:
             name: {{ .Values.jaeger.serviceName }}-ui-configuration
             defaultMode: 420
-        - name: query-config
+        - name: query-runtime-config
           secret:
             secretName: {{ include "query.runtimeConfig.secretName" . }}
             items:
@@ -261,7 +265,9 @@ spec:
             defaultMode: 420
           {{- end }}
         {{- end }}
-        {{- include "jaeger.certificateVolumes" . | nindent 8 }}
+        {{- with (include "jaeger.certificateVolumes" . | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       {{- if .Values.query.affinity }}
       affinity:
         {{- toYaml .Values.query.affinity | nindent 8 }}

--- a/charts/qubership-jaeger/templates/query/ingress.yaml
+++ b/charts/qubership-jaeger/templates/query/ingress.yaml
@@ -20,10 +20,10 @@ metadata:
     {{- if .Values.query.ingress.labels }}
       {{- toYaml .Values.query.ingress.labels | nindent 4 }}
     {{- end }}
+  {{- if $annotations }}
   annotations:
-    {{- if $annotations }}
     {{- toYaml $annotations | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   {{- if .Values.query.ingress.className }}
   ingressClassName: {{ .Values.query.ingress.className }}

--- a/charts/qubership-jaeger/templates/query/ingress.yaml
+++ b/charts/qubership-jaeger/templates/query/ingress.yaml
@@ -21,7 +21,6 @@ metadata:
       {{- toYaml .Values.query.ingress.labels | nindent 4 }}
     {{- end }}
   annotations:
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
     {{- if $annotations }}
     {{- toYaml $annotations | nindent 4 }}
     {{- end }}

--- a/charts/qubership-jaeger/values.schema.json
+++ b/charts/qubership-jaeger/values.schema.json
@@ -998,9 +998,9 @@
             "limits": {
               "properties": {
                 "cpu": {
-                  "default": 1,
+                  "default": "1000m",
                   "title": "cpu",
-                  "type": "integer"
+                  "type": "string"
                 },
                 "memory": {
                   "default": "512Mi",

--- a/charts/qubership-jaeger/values.schema.json
+++ b/charts/qubership-jaeger/values.schema.json
@@ -164,7 +164,7 @@
                 "cpu": {
                   "default": "500m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "256Mi",
@@ -180,7 +180,7 @@
                 "cpu": {
                   "default": "50m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "50Mi",
@@ -1000,7 +1000,7 @@
                 "cpu": {
                   "default": "1000m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "512Mi",
@@ -1016,7 +1016,7 @@
                 "cpu": {
                   "default": "100m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "100Mi",
@@ -1573,7 +1573,7 @@
                     "cpu": {
                       "default": "100m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -1589,7 +1589,7 @@
                     "cpu": {
                       "default": "100m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -1770,7 +1770,7 @@
                     "cpu": {
                       "default": "100m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -1786,7 +1786,7 @@
                     "cpu": {
                       "default": "100m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -1998,7 +1998,7 @@
                     "cpu": {
                       "default": "100m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -2014,7 +2014,7 @@
                     "cpu": {
                       "default": "100m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -2291,7 +2291,7 @@
                 "cpu": {
                   "default": "100m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "128Mi",
@@ -2307,7 +2307,7 @@
                 "cpu": {
                   "default": "100m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "128Mi",
@@ -2442,7 +2442,7 @@
                 "cpu": {
                   "default": "300m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "256Mi",
@@ -2458,7 +2458,7 @@
                 "cpu": {
                   "default": "50m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "64Mi",
@@ -2712,7 +2712,7 @@
                 "cpu": {
                   "default": "100m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "200Mi",
@@ -2728,7 +2728,7 @@
                 "cpu": {
                   "default": "50m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "100Mi",
@@ -2957,7 +2957,7 @@
                 "cpu": {
                   "default": "200m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "256Mi",
@@ -2973,7 +2973,7 @@
                 "cpu": {
                   "default": "100m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "128Mi",
@@ -3116,7 +3116,7 @@
                 "cpu": {
                   "default": "50m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "50Mi",
@@ -3132,7 +3132,7 @@
                 "cpu": {
                   "default": "50m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "50Mi",
@@ -3312,7 +3312,7 @@
                     "cpu": {
                       "default": "100m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -3328,7 +3328,7 @@
                     "cpu": {
                       "default": "10m",
                       "title": "cpu",
-                      "type": "string"
+                      "type": ["integer", "string"]
                     },
                     "memory": {
                       "default": "128Mi",
@@ -3382,7 +3382,7 @@
                 "cpu": {
                   "default": "500m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "1Gi",
@@ -3398,7 +3398,7 @@
                 "cpu": {
                   "default": "100m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "100Mi",
@@ -3535,7 +3535,7 @@
                 "cpu": {
                   "default": "100m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "100Mi",
@@ -3551,7 +3551,7 @@
                 "cpu": {
                   "default": "50m",
                   "title": "cpu",
-                  "type": "string"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "default": "50Mi",

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -1678,7 +1678,7 @@ collector:
       # GATEWAY_SYSTEM_TYPE allows creating Ingresses. Set it to "false" to never create it.
       # Type: boolean
       # Mandatory: no
-      # Default: not set
+      # Default: false
       #
       install: false
 
@@ -1722,7 +1722,7 @@ collector:
       # GATEWAY_SYSTEM_TYPE allows creating Ingresses. Set it to "false" to never create it.
       # Type: boolean
       # Mandatory: no
-      # Default: not set
+      # Default: false
       #
       install: false
 
@@ -1759,7 +1759,7 @@ collector:
     # Set it to "false" to never create it.
     # Type: boolean
     # Mandatory: no
-    # Default: not set
+    # Default: false
     #
     install: false
 
@@ -1815,7 +1815,7 @@ collector:
     # Set it to "false" to never create it.
     # Type: boolean
     # Mandatory: no
-    # Default: not set
+    # Default: false
     #
     install: false
 

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -1680,7 +1680,8 @@ collector:
       # Mandatory: no
       # Default: not set
       #
-      # install: true
+      install: false
+
       # Add annotation that prevents Gateway API converter from processing this Ingress.
       # Use it when HTTPRoute/GRPCRoute analogue is already configured.
       # The annotation is added automatically when GATEWAY_SYSTEM_TYPE contains "gateway-api-default".
@@ -1723,7 +1724,8 @@ collector:
       # Mandatory: no
       # Default: not set
       #
-      # install: true
+      install: false
+
       # Add annotation that prevents Gateway API converter from processing this Ingress.
       # Use it when HTTPRoute/GRPCRoute analogue is already configured.
       # The annotation is added automatically when GATEWAY_SYSTEM_TYPE contains "gateway-api-default".
@@ -1759,7 +1761,8 @@ collector:
     # Mandatory: no
     # Default: not set
     #
-    # install: true
+    install: false
+
     labels: {}
     annotations: {}
     # List of parent Gateway references. When the list is empty, the route is attached to the
@@ -1814,7 +1817,8 @@ collector:
     # Mandatory: no
     # Default: not set
     #
-    # install: true
+    install: false
+
     # Available values: HTTPRoute, GRPCRoute
     #
     kind: HTTPRoute
@@ -1858,7 +1862,6 @@ collector:
     #   - name: jaeger-collector
     #     port: 4317
     rules: []
-
 
   # Jaeger collector config, contains only several options to configure, other part of parameters take from
   # cassandraSchemaJob and elasticsearch sections

--- a/charts/qubership-jaeger/values.yaml
+++ b/charts/qubership-jaeger/values.yaml
@@ -1611,7 +1611,7 @@ collector:
   #
   resources:
     limits:
-      cpu: 1
+      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m


### PR DESCRIPTION
# Why

After merging the latest changes from PRs:
- https://github.com/Netcracker/qubership-jaeger/pull/352
- https://github.com/Netcracker/qubership-jaeger/pull/299

this Helm chart deployment using ArgoCD fails with the error:

```bash
one or more objects failed to apply, reason: Deployment.apps "jaeger-collector" is invalid: [spec.template.spec.volumes[1].configMap: Forbidden: may not specify more than 1 volume type, spec.template.spec.containers[0].volumeMounts[1].name: Not found: "collector-config"],Deployment.apps "jaeger-query" is invalid: [spec.template.spec.volumes[1].configMap: Forbidden: may not specify more than 1 volume type, spec.template.spec.containers[0].volumeMounts[1].name: Not found: "query-config", spec.template.spec.containers[1].image: Required value]
```

# What

In merged PRs, Jaeger configuration moved from a ConfigMap to a Secret.  When Argo CD does a client-side strategic-merge patch, it doesn't replace the volume list because nothing changed in the list of volumes.

So to fix this issue need to do the following:
- Renamed configuration secrets for clarity, changing `collector-config` to `collector-runtime-config` and `query-config` to `query-runtime-config`.

Additional changes:
- Updated deployment templates for collector and query components to utilize the new environment variable helper, enhancing maintainability and readability.
- Updated deployment templates to avoid rendering empty sections `env:` and `volumeMounts:`
- Removed hardcoded annotation `nginx.ingress.kubernetes.io/proxy-buffer-size: 256k` that may lead to an error in ingress-nginx:
```bash
Error: exit status 1
2026/08/05 08:09:19 [warn] 18079#18079: could not build optimal proxy_headers_hash, you should increase either proxy_headers_hash_max_size: 512 or proxy_headers_hash_bucket_size: 64; ignoring proxy_headers_hash_bucket_size
nginx: [warn] could not build optimal proxy_headers_hash, you should increase either proxy_headers_hash_max_size: 512 or proxy_headers_hash_bucket_size: 64; ignoring proxy_headers_hash_bucket_size
2026/08/05 08:09:19 [emerg] 18079#18079: "proxy_busy_buffers_size" must be equal to or greater than the maximum of the value of "proxy_buffer_size" and one of the "proxy_buffers" in /tmp/nginx/nginx-cfg1847574067:58354
nginx: [emerg] "proxy_busy_buffers_size" must be equal to or greater than the maximum of the value of "proxy_buffer_size" and one of the "proxy_buffers" in /tmp/nginx/nginx-cfg1847574067:58354
nginx: configuration file /tmp/nginx/nginx-cfg1847574067 test failed
```
- Disable Ingresses and HTTPRoutes for jaeger-collector by default

# How to verify

- Render locally using `helm template ...`
- Deploy in Kubernetes using ArgoCD