### PR TITLE
fix(ci): separate local and external link checks

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,21 +1,59 @@
 ---
 name: Link Checker
+run-name: "Link check: ${{ github.event_name }}"
 
 on:
-  push: null
-  repository_dispatch: null
-  workflow_dispatch: null
   pull_request:
     branches: [main]
     types:
       [opened, reopened, synchronize]
-permissions:
-  contents: read
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: link-checker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  linkChecker:
+  repository-local-links:
+    name: Repository-local links
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check repository-local links
+        id: lychee
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        with:
+          args: >-
+            './**/*.md'
+            --offline
+            --include-fragments
+            --verbose
+            --no-progress
+          format: markdown
+          fail: true
+
+  external-link-availability:
+    name: External link availability (advisory)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Restore lychee cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -25,7 +63,7 @@ jobs:
           key: cache-lychee-${{ github.sha }}
           restore-keys: cache-lychee-
 
-      - name: Link Checker
+      - name: Check external link availability
         id: lychee
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:


### PR DESCRIPTION
## Why

Pull requests should not be blocked by transient external-link availability failures.

## What

- Run repository-local Markdown link and fragment validation on pull requests.
- Keep external-link availability checks visible on scheduled and manually dispatched runs, while pull requests block only on repository-local links.
- Relates to #369.

## How to verify

- Run `actionlint .github/workflows/link-checker.yaml`.
- Run Lychee v0.24.2 with `--offline --include-fragments` against the repository Markdown files.
- Confirm a missing local fragment fails and a valid local fragment passes.